### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ If Godot is on your `PATH`, you can omit `GODOT_PATH` entirely. The server will 
 
 Ask your AI assistant to call `get_project_info`. If it returns a Godot version string (e.g., `4.4.stable`), you're connected and working.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/erodenn-godot-mcp-runtime).
+
 ## Tools
 
 ### Project Management


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/erodenn-godot-mcp-runtime).