### PR TITLE
feat: add manual attach mode for runtime tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ When you run a project through this server, it injects a lightweight UDP bridge 
 
 **The distinction matters: the AI doesn't just write your game, it can check its work.**
 
-**No addon required.** Most Godot MCP servers that offer runtime support ship as a Godot addon — something you install into your project, commit to version control, and manage as a dependency. This server does none of that. The bridge script is injected on `run_project` and removed on `stop_project`. Your project files are left exactly as they were. All you need is Node.js and a Godot executable — no addon installation, no project modifications, no cleanup.
+**No addon required.** Most Godot MCP servers that offer runtime support ship as a Godot addon — something you install into your project, commit to version control, and manage as a dependency. This server does none of that. The bridge script is injected on `run_project` or `attach_project`, then removed on `stop_project` / `detach_project`. Your project files are left exactly as they were. All you need is Node.js and a Godot executable — no addon installation, no project modifications, no cleanup.
 
 <a href="https://glama.ai/mcp/servers/@Erodenn/godot-runtime-mcp">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@Erodenn/godot-runtime-mcp/badge" alt="godot-runtime-mcp MCP server" />
@@ -27,7 +27,7 @@ Every operation is its own tool with only its relevant parameters — no operati
 
 **Headless editing.** Create scenes, add nodes, set properties, attach scripts, connect signals, manage UIDs, validate GDScript. All the standard operations, no editor window required.
 
-**Runtime bridge.** When `run_project` is called, the server injects `McpBridge` as an autoload. This opens a UDP channel on port 9900 (localhost only) and enables:
+**Runtime bridge.** When `run_project` or `attach_project` is called, the server injects `McpBridge` as an autoload. This opens a UDP channel on port 9900 (localhost only) and enables:
 
 - **Screenshots:** Capture the viewport at any point during gameplay
 - **Input simulation:** Batched sequences of key presses, mouse clicks, mouse motion, UI element clicks by name or path, Godot action events, and timed waits
@@ -36,7 +36,9 @@ Every operation is its own tool with only its relevant parameters — no operati
 
 **Background mode.** Pass `background: true` to `run_project` and the Godot window moves off-screen with physical input blocked — borderless, unfocusable, mouse-passthrough. Programmatic input, screenshots, and all runtime tools work exactly the same. Useful for automated agent-driven testing where the window shouldn't be visible or interactive.
 
-The bridge cleans itself up automatically when `stop_project` is called. No leftover autoloads, no modified project files.
+**Manual attach mode.** Use `attach_project` when you want MCP runtime tools against a Godot process you will launch yourself from a shell or another harness. `attach_project` injects the bridge and marks the project as active without spawning Godot. `detach_project` removes the injected bridge state later. In attached mode, `get_debug_output` reports that stdout/stderr capture is unavailable because MCP did not launch the process.
+
+The bridge cleans itself up automatically when `stop_project` or `detach_project` is called. No leftover autoloads, no modified project files.
 
 ## Quick Start
 
@@ -123,14 +125,16 @@ Ask your AI assistant to call `get_project_info`. If it returns a Godot version 
 |------|-------------|
 | `launch_editor` | Open the Godot editor GUI for a project |
 | `run_project` | Run a project in debug mode and inject the MCP bridge. Pass `background: true` to hide the window |
-| `stop_project` | Stop the running project and remove the bridge |
-| `get_debug_output` | Read stdout/stderr from the running project |
+| `attach_project` | Inject the MCP bridge and mark a project active without spawning Godot |
+| `detach_project` | Clear attached-mode state and remove the injected bridge without claiming the external process was stopped |
+| `stop_project` | Stop the running project and remove the bridge, or detach attached-mode state |
+| `get_debug_output` | Read stdout/stderr from an MCP-spawned project; attached mode reports that capture is unavailable |
 | `list_projects` | Find Godot projects in a directory |
 | `get_project_info` | Get project metadata and Godot version |
 
-### Runtime (requires `run_project` first)
+### Runtime (requires `run_project` or `attach_project` first)
 
-After calling `run_project`, wait 2-3 seconds for the bridge to initialize before using these tools.
+After calling `run_project`, or after `attach_project` plus launching Godot manually, wait 2-3 seconds for the bridge to initialize before using these tools.
 
 | Tool | Description |
 |------|-------------|
@@ -224,6 +228,15 @@ When `run_project` is called:
 3. The project launches with the bridge listening on `127.0.0.1:9900`
 4. Runtime tools send JSON commands to the bridge and await responses
 5. When `stop_project` is called, the autoload entry and bridge script are removed
+
+When `attach_project` is called:
+
+1. `mcp_bridge.gd` is copied into the project directory
+2. It's registered as an autoload in `project.godot`
+3. The server records the project as an attached runtime target without spawning Godot
+4. You launch Godot yourself, and the bridge listens on `127.0.0.1:9900`
+5. Runtime tools send JSON commands to the bridge and await responses
+6. `detach_project` or `stop_project` removes the injected bridge state later
 
 Files generated during runtime (screenshots, executed scripts) are stored in `.mcp/` inside the project directory. This directory is automatically added to `.gitignore` and has a `.gdignore` so Godot won't import it.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ import {
   projectToolDefinitions,
   handleLaunchEditor,
   handleRunProject,
+  handleAttachProject,
+  handleDetachProject,
   handleGetDebugOutput,
   handleStopProject,
   handleListProjects,
@@ -94,10 +96,10 @@ class GodotMcpServer {
         instructions: `Godot MCP Server — AI-driven Godot 4.x project manipulation.
 
 Tool categories:
-- Project management: launch_editor, run_project, stop_project, get_debug_output, list_projects, get_project_info
+- Project management: launch_editor, run_project, attach_project, detach_project, stop_project, get_debug_output, list_projects, get_project_info
 - Scene editing (headless): create_scene, add_node, load_sprite, save_scene, export_mesh_library, batch_scene_operations
 - Node editing (headless): delete_node, set_node_property, batch_set_node_properties, get_node_properties, batch_get_node_properties, attach_script, get_scene_tree, duplicate_node, get_node_signals, connect_signal, disconnect_signal
-- Runtime (requires run_project): take_screenshot, simulate_input, get_ui_elements, run_script
+- Runtime (requires run_project or attach_project): take_screenshot, simulate_input, get_ui_elements, run_script
 - Project config (no Godot process): list_autoloads, add_autoload, remove_autoload, update_autoload, get_project_files, search_project, get_scene_dependencies, get_project_settings
 - Validation: validate
 - UIDs (Godot 4.4+): manage_uids
@@ -106,6 +108,7 @@ Key behaviors:
 - All mutation operations (add_node, set_node_property, delete_node, etc.) save the scene automatically. Only use save_scene for save-as (newPath) or re-canonicalization.
 - Headless Godot initializes ALL registered autoloads. If any autoload is broken, headless operations will fail. Use list_autoloads / remove_autoload to diagnose.
 - After run_project, wait 2-3 seconds before using runtime tools (take_screenshot, simulate_input, get_ui_elements, run_script). The MCP bridge needs time to initialize.
+- attach_project is the fallback path for a manually launched Godot process. It injects the bridge and marks the project active, but it does not spawn Godot or capture stdout/stderr.
 - click_element in simulate_input resolves by node path or node name (BFS search), NOT by visible text. Use get_ui_elements to discover valid element identifiers.
 - run_script expects GDScript with "extends RefCounted" and "func execute(scene_tree: SceneTree) -> Variant".`,
       }
@@ -157,6 +160,10 @@ Key behaviors:
           return await handleLaunchEditor(this.runner, args);
         case 'run_project':
           return await handleRunProject(this.runner, args);
+        case 'attach_project':
+          return await handleAttachProject(this.runner, args);
+        case 'detach_project':
+          return handleDetachProject(this.runner);
         case 'get_debug_output':
           return handleGetDebugOutput(this.runner, args);
         case 'stop_project':

--- a/src/scripts/mcp_bridge.gd
+++ b/src/scripts/mcp_bridge.gd
@@ -5,6 +5,7 @@ var port: int = 9900
 var _is_processing_input: bool = false
 
 func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	udp_server = UDPServer.new()
 	var err = udp_server.listen(port, "127.0.0.1")
 	if err != OK:

--- a/src/tools/project-tools.ts
+++ b/src/tools/project-tools.ts
@@ -126,7 +126,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'run_project',
-    description: 'Run a Godot project in debug mode. Required before calling take_screenshot, simulate_input, get_ui_elements, run_script, or get_debug_output. After starting, wait 2–3 seconds for the MCP bridge to initialize before using those tools. Call stop_project when done.',
+    description: 'Run a Godot project in debug mode. Preferred path for runtime tools. Required before calling take_screenshot, simulate_input, get_ui_elements, run_script, or get_debug_output unless you intentionally use attach_project for a manually launched game. After starting, wait 2–3 seconds for the MCP bridge to initialize before using runtime tools. Call stop_project when done.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -147,8 +147,31 @@ export const projectToolDefinitions: ToolDefinition[] = [
     },
   },
   {
+    name: 'attach_project',
+    description: 'Attach runtime MCP tools to a project without spawning Godot. This injects the McpBridge autoload and marks the project as the active runtime session so you can launch the game manually from your own shell, then use take_screenshot, simulate_input, get_ui_elements, and run_script against that running game. Use detach_project or stop_project when done. get_debug_output is not available in attached mode because stdout/stderr are not captured.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Path to the Godot project directory',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'detach_project',
+    description: 'Clear attached-mode runtime state and remove the injected McpBridge autoload without claiming that the manually launched Godot process was stopped.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+  },
+  {
     name: 'get_debug_output',
-    description: 'Get stdout/stderr output from the running Godot project. Requires run_project first. Returns the last N lines of output and errors, a running flag, and an exit code if the process has ended. Use this to check GDScript errors, print() calls, and crash messages.',
+    description: 'Get stdout/stderr output from the running Godot project. Requires run_project first. Returns the last N lines of output and errors, a running flag, and an exit code if the process has ended. In attached mode, this reports that stdout/stderr capture is unavailable because Godot was launched outside MCP.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -396,6 +419,24 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
 ];
 
+function ensureRuntimeSession(runner: GodotRunner, actionDescription: string) {
+  if (!runner.activeSessionMode || !runner.activeProjectPath) {
+    return createErrorResponse(
+      `No active runtime session. A project must be running or attached to ${actionDescription}.`,
+      ['Use run_project to start a Godot project first', 'Or use attach_project before launching Godot manually']
+    );
+  }
+
+  if (runner.activeSessionMode === 'spawned' && (!runner.activeProcess || runner.activeProcess.hasExited)) {
+    return createErrorResponse(
+      `The spawned Godot process has exited and cannot ${actionDescription}.`,
+      ['Use get_debug_output to inspect the last captured logs', 'Call stop_project to clean up, then run_project again']
+    );
+  }
+
+  return null;
+}
+
 function findGodotProjects(directory: string, recursive: boolean): Array<{ path: string; name: string }> {
   const projects: Array<{ path: string; name: string }> = [];
 
@@ -580,18 +621,115 @@ export async function handleRunProject(runner: GodotRunner, args: OperationParam
   }
 }
 
+export async function handleAttachProject(runner: GodotRunner, args: OperationParams) {
+  args = normalizeParameters(args);
+
+  if (!args.projectPath) {
+    return createErrorResponse(
+      'Project path is required',
+      ['Provide a valid path to a Godot project directory']
+    );
+  }
+
+  if (!validatePath(args.projectPath as string)) {
+    return createErrorResponse(
+      'Invalid project path',
+      ['Provide a valid path without ".." or other potentially unsafe characters']
+    );
+  }
+
+  try {
+    const projectFile = join(args.projectPath as string, 'project.godot');
+    if (!existsSync(projectFile)) {
+      return createErrorResponse(
+        `Not a valid Godot project: ${args.projectPath}`,
+        ['Ensure the path points to a directory containing a project.godot file', 'Use list_projects to find valid Godot projects']
+      );
+    }
+
+    runner.attachProject(args.projectPath as string);
+
+    return {
+      content: [{
+        type: 'text',
+        text: [
+          'Project attached for manual runtime use.',
+          '- Launch Godot yourself after this call so the injected McpBridge can initialize',
+          '- Wait 2–3 seconds after launch before calling take_screenshot, simulate_input, get_ui_elements, or run_script',
+          '- get_debug_output is unavailable in attached mode because MCP did not spawn the process',
+          '- Use detach_project or stop_project when done to clean up the injected bridge state',
+        ].join('\n'),
+      }],
+    };
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return createErrorResponse(
+      `Failed to attach project: ${errorMessage}`,
+      ['Check if project.godot is accessible', 'Ensure MCP can write the bridge autoload into the project']
+    );
+  }
+}
+
+export function handleDetachProject(runner: GodotRunner) {
+  if (runner.activeSessionMode !== 'attached') {
+    return createErrorResponse(
+      'No attached project to detach.',
+      ['Use attach_project first for manual-launch workflows', 'If MCP launched the game, use stop_project instead']
+    );
+  }
+
+  const result = runner.stopProject();
+  if (!result) {
+    return createErrorResponse(
+      'No attached project to detach.',
+      ['Use attach_project first for manual-launch workflows']
+    );
+  }
+
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify({
+        message: 'Detached attached project and cleaned MCP bridge state',
+        externalProcessPreserved: result.externalProcessPreserved === true,
+      }),
+    }],
+  };
+}
+
 export function handleGetDebugOutput(runner: GodotRunner, args: OperationParams = {}) {
   args = normalizeParameters(args);
 
-  if (!runner.activeProcess) {
+  if (!runner.activeSessionMode) {
     return createErrorResponse(
-      'No active Godot process.',
-      ['Use run_project to start a Godot project first', 'Check if the Godot process crashed unexpectedly']
+      'No active runtime session.',
+      ['Use run_project to start a Godot project first', 'Or use attach_project before launching Godot manually']
     );
+  }
+
+  if (runner.activeSessionMode === 'attached') {
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          output: [],
+          errors: [],
+          running: null,
+          attached: true,
+          tip: 'Attached mode does not capture stdout/stderr because Godot was launched outside MCP.',
+        }),
+      }],
+    };
   }
 
   const limit = typeof args.limit === 'number' ? args.limit : 200;
   const proc = runner.activeProcess;
+  if (!proc) {
+    return createErrorResponse(
+      'No active spawned process is available for debug output.',
+      ['Use run_project to start a Godot project first', 'Or use attach_project only when stdout/stderr capture is not needed']
+    );
+  }
   const response: {
     output: string[];
     errors: string[];
@@ -631,7 +769,11 @@ export function handleStopProject(runner: GodotRunner) {
     content: [{
       type: 'text',
       text: JSON.stringify({
-        message: 'Godot project stopped',
+        message: result.mode === 'attached'
+          ? 'Attached project detached and MCP bridge state cleaned up'
+          : 'Godot project stopped',
+        mode: result.mode,
+        externalProcessPreserved: result.externalProcessPreserved === true,
         finalOutput: result.output.slice(-200),
         finalErrors: result.errors.slice(-200),
       }),
@@ -744,11 +886,9 @@ export async function handleGetProjectInfo(runner: GodotRunner, args: OperationP
 export async function handleTakeScreenshot(runner: GodotRunner, args: OperationParams) {
   args = normalizeParameters(args);
 
-  if (!runner.activeProcess || runner.activeProcess.hasExited) {
-    return createErrorResponse(
-      'No active Godot process. A project must be running to take a screenshot.',
-      ['Use run_project to start a Godot project first', 'Wait a few seconds after starting for the game to initialize']
-    );
+  const sessionError = ensureRuntimeSession(runner, 'take a screenshot');
+  if (sessionError) {
+    return sessionError;
   }
 
   const timeout = typeof args.timeout === 'number' ? args.timeout : 10000;
@@ -822,11 +962,9 @@ export async function handleTakeScreenshot(runner: GodotRunner, args: OperationP
 export async function handleSimulateInput(runner: GodotRunner, args: OperationParams) {
   args = normalizeParameters(args);
 
-  if (!runner.activeProcess || runner.activeProcess.hasExited) {
-    return createErrorResponse(
-      'No active Godot process. A project must be running to simulate input.',
-      ['Use run_project to start a Godot project first', 'Wait a few seconds after starting for the game to initialize']
-    );
+  const sessionError = ensureRuntimeSession(runner, 'simulate input');
+  if (sessionError) {
+    return sessionError;
   }
 
   const actions = args.actions;
@@ -892,11 +1030,9 @@ export async function handleSimulateInput(runner: GodotRunner, args: OperationPa
 export async function handleGetUiElements(runner: GodotRunner, args: OperationParams) {
   args = normalizeParameters(args);
 
-  if (!runner.activeProcess || runner.activeProcess.hasExited) {
-    return createErrorResponse(
-      'No active Godot process. A project must be running to query UI elements.',
-      ['Use run_project to start a Godot project first', 'Wait a few seconds after starting for the game to initialize']
-    );
+  const sessionError = ensureRuntimeSession(runner, 'query UI elements');
+  if (sessionError) {
+    return sessionError;
   }
 
   const visibleOnly = args.visibleOnly !== false;
@@ -948,11 +1084,9 @@ export async function handleGetUiElements(runner: GodotRunner, args: OperationPa
 export async function handleRunScript(runner: GodotRunner, args: OperationParams) {
   args = normalizeParameters(args);
 
-  if (!runner.activeProcess || runner.activeProcess.hasExited) {
-    return createErrorResponse(
-      'No active Godot process. A project must be running to execute scripts.',
-      ['Use run_project to start a Godot project first', 'Wait a few seconds after starting for the game to initialize']
-    );
+  const sessionError = ensureRuntimeSession(runner, 'execute scripts');
+  if (sessionError) {
+    return sessionError;
   }
 
   const script = args.script;
@@ -1389,4 +1523,3 @@ export async function handleGetProjectSettings(args: OperationParams) {
     return createErrorResponse(`Failed to get project settings: ${errorMessage}`, ['Check if project.godot is accessible']);
   }
 }
-

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -86,6 +86,15 @@ export interface GodotProcess {
   hasExited: boolean;
 }
 
+export type RuntimeSessionMode = 'spawned' | 'attached';
+
+export interface RuntimeStopResult {
+  mode: RuntimeSessionMode;
+  output: string[];
+  errors: string[];
+  externalProcessPreserved?: boolean;
+}
+
 export interface GodotServerConfig {
   godotPath?: string;
   debugMode?: boolean;
@@ -308,6 +317,7 @@ export class GodotRunner {
   private strictPathValidation: boolean;
   public activeProcess: GodotProcess | null = null;
   public activeProjectPath: string | null = null;
+  public activeSessionMode: RuntimeSessionMode | null = null;
 
   constructor(config?: GodotServerConfig) {
     this.strictPathValidation = config?.strictPathValidation ?? false;
@@ -564,13 +574,14 @@ export class GodotRunner {
       throw new Error('Godot path not set. Call detectGodotPath first.');
     }
 
-    if (this.activeProcess) {
+    if (this.activeSessionMode === 'spawned' && this.activeProcess) {
       logDebug('Killing existing Godot process before starting a new one');
       this.activeProcess.process.kill();
-      // Clean up old project's autoload if switching projects
       if (this.activeProjectPath && this.activeProjectPath !== projectPath) {
         this.cleanupBridgeAutoload(this.activeProjectPath);
       }
+    } else if (this.activeSessionMode === 'attached' && this.activeProjectPath && this.activeProjectPath !== projectPath) {
+      this.cleanupBridgeAutoload(this.activeProjectPath);
     }
 
     try {
@@ -579,6 +590,7 @@ export class GodotRunner {
       logDebug(`Non-fatal: Failed to inject bridge autoload: ${err}`);
     }
     this.activeProjectPath = projectPath;
+    this.activeSessionMode = 'spawned';
 
     const cmdArgs = ['-d', '--path', projectPath];
     if (scene && validatePath(scene)) {
@@ -638,14 +650,50 @@ export class GodotRunner {
     return this.activeProcess;
   }
 
-  stopProject(): { output: string[]; errors: string[] } | null {
+  attachProject(projectPath: string): void {
+    if (this.activeSessionMode === 'spawned' && this.activeProcess) {
+      this.stopProject();
+    } else if (this.activeSessionMode === 'attached' && this.activeProjectPath && this.activeProjectPath !== projectPath) {
+      this.cleanupBridgeAutoload(this.activeProjectPath);
+      this.activeProjectPath = null;
+      this.activeSessionMode = null;
+    }
+
+    this.injectBridgeAutoload(projectPath);
+    this.activeProjectPath = projectPath;
+    this.activeSessionMode = 'attached';
+    this.activeProcess = null;
+  }
+
+  stopProject(): RuntimeStopResult | null {
+    if (!this.activeSessionMode) {
+      return null;
+    }
+
+    if (this.activeSessionMode === 'attached') {
+      const projectPath = this.activeProjectPath;
+      if (projectPath) {
+        this.cleanupBridgeAutoload(projectPath);
+      }
+      this.activeProjectPath = null;
+      this.activeSessionMode = null;
+      this.activeProcess = null;
+      return {
+        mode: 'attached',
+        output: [],
+        errors: [],
+        externalProcessPreserved: true,
+      };
+    }
+
     if (!this.activeProcess) {
       return null;
     }
 
     logDebug('Stopping active Godot process');
     this.activeProcess.process.kill();
-    const result = {
+    const result: RuntimeStopResult = {
+      mode: 'spawned',
       output: this.activeProcess.output,
       errors: this.activeProcess.errors,
     };
@@ -655,8 +703,19 @@ export class GodotRunner {
       this.cleanupBridgeAutoload(this.activeProjectPath);
       this.activeProjectPath = null;
     }
+    this.activeSessionMode = null;
 
     return result;
+  }
+
+  hasActiveRuntimeSession(): boolean {
+    if (!this.activeSessionMode || !this.activeProjectPath) {
+      return false;
+    }
+    if (this.activeSessionMode === 'spawned') {
+      return this.activeProcess !== null && !this.activeProcess.hasExited;
+    }
+    return true;
   }
 
   private removeAutoloadEntry(projectPath: string, entryName: string, scriptFilename: string): void {


### PR DESCRIPTION
  Summary                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - Add attach_project / detach_project tools for using runtime MCP tools (screenshots, input simulation, UI queries, script execution) against a Godot process launched outside MCP                                                                                                                                                                                                                                             
  - Bridge injection and cleanup works identically to run_project / stop_project — zero project footprint
  - get_debug_output gracefully reports that stdout/stderr capture is unavailable in attached mode                                                                                                                                                                                                                                                                                                                               
  - Set McpBridge process_mode to PROCESS_MODE_ALWAYS so the bridge stays responsive when the scene tree is paused                                                                                                                                                                                                                                                                                                               
   
  Motivation                                                                                                                                                                                                                                                                                                                                                                                                                     
                  
  run_project requires MCP to own the Godot process lifecycle. This doesn't work when another tool, CI pipeline, or manual workflow needs to launch the game. attach_project fills that gap while reusing all existing bridge infrastructure.                                                                                                                                                                                    
   
  Test plan                                                                                                                                                                                                                                                                                                                                                                                                                      
                  
  - attach_project injects bridge and marks session active
  - Launch Godot manually — runtime tools (screenshot, input, UI, run_script) work against it
  - get_debug_output returns informative message about capture being unavailable                                                                                                                                                                                                                                                                                                                                                 
  - detach_project cleans up bridge without affecting the external process
                                                                            