### PR TITLE
feat: verify Godot bridge readiness before runtime use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ Tool categories:
 Key behaviors:
 - All mutation operations (add_node, set_node_property, delete_node, etc.) save the scene automatically. Only use save_scene for save-as (newPath) or re-canonicalization.
 - Headless Godot initializes ALL registered autoloads. If any autoload is broken, headless operations will fail. Use list_autoloads / remove_autoload to diagnose.
-- After run_project, wait 2-3 seconds before using runtime tools (take_screenshot, simulate_input, get_ui_elements, run_script). The MCP bridge needs time to initialize.
+- run_project verifies bridge readiness before returning success. If it reports degraded status, retry runtime tools after a moment or check get_debug_output.
 - attach_project is the fallback path for a manually launched Godot process. It injects the bridge and marks the project active, but it does not spawn Godot or capture stdout/stderr.
 - click_element in simulate_input resolves by node path or node name (BFS search), NOT by visible text. Use get_ui_elements to discover valid element identifiers.
 - run_script expects GDScript with "extends RefCounted" and "func execute(scene_tree: SceneTree) -> Variant".

--- a/src/scripts/mcp_bridge.gd
+++ b/src/scripts/mcp_bridge.gd
@@ -74,7 +74,7 @@ func _handle_json_command(peer: PacketPeerUDP, data: String) -> void:
 		"screenshot":
 			_handle_screenshot(peer)
 		"ping":
-			_send_response(peer, {"status": "pong", "session_token": session_token})
+			_send_response(peer, {"status": "pong", "session_token": session_token, "project_path": ProjectSettings.globalize_path("res://")})
 		_:
 			_send_response(peer, {"error": "Unknown command: %s" % command})
 

--- a/src/scripts/mcp_bridge.gd
+++ b/src/scripts/mcp_bridge.gd
@@ -3,9 +3,11 @@ extends Node
 var udp_server: UDPServer
 var port: int = 9900
 var _is_processing_input: bool = false
+var session_token: String = ""
 
 func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
+	session_token = OS.get_environment("MCP_SESSION_TOKEN")
 	udp_server = UDPServer.new()
 	var err = udp_server.listen(port, "127.0.0.1")
 	if err != OK:
@@ -72,7 +74,7 @@ func _handle_json_command(peer: PacketPeerUDP, data: String) -> void:
 		"screenshot":
 			_handle_screenshot(peer)
 		"ping":
-			_send_response(peer, {"status": "pong"})
+			_send_response(peer, {"status": "pong", "session_token": session_token})
 		_:
 			_send_response(peer, {"error": "Unknown command: %s" % command})
 

--- a/src/tools/project-tools.ts
+++ b/src/tools/project-tools.ts
@@ -150,13 +150,17 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'attach_project',
-    description: 'Attach runtime MCP tools to a project without spawning Godot. This injects the McpBridge autoload and marks the project as the active runtime session so you can launch the game manually from your own shell, then use take_screenshot, simulate_input, get_ui_elements, and run_script against that running game. Use detach_project or stop_project when done. get_debug_output is not available in attached mode because stdout/stderr are not captured.',
+    description: 'Attach runtime MCP tools to a project without spawning Godot. This injects the McpBridge autoload and marks the project as the active runtime session so you can launch the game manually from your own shell, then use take_screenshot, simulate_input, get_ui_elements, and run_script against that running game. Set waitForBridge to true after launching Godot to block until the bridge is confirmed ready. Use detach_project or stop_project when done. get_debug_output is not available in attached mode because stdout/stderr are not captured.',
     inputSchema: {
       type: 'object',
       properties: {
         projectPath: {
           type: 'string',
           description: 'Path to the Godot project directory',
+        },
+        waitForBridge: {
+          type: 'boolean',
+          description: 'If true, poll the bridge until it responds (up to 15 seconds). Use this after Godot is already running to confirm runtime tools are ready. Defaults to false.',
         },
       },
       required: ['projectPath'],
@@ -686,13 +690,45 @@ export async function handleAttachProject(runner: GodotRunner, args: OperationPa
 
     runner.attachProject(args.projectPath as string);
 
+    if (args.waitForBridge === true) {
+      const bridgeResult = await runner.waitForBridgeAttached();
+
+      if (!bridgeResult.ready) {
+        return {
+          content: [{
+            type: 'text',
+            text: [
+              'Project attached but the MCP bridge did not respond within 15 seconds.',
+              '- Verify Godot is running with this project',
+              '- The McpBridge autoload must be initialized and listening on UDP port 9900',
+              '- Runtime tools may work if you retry after a moment',
+              '- get_debug_output is unavailable in attached mode',
+              '- Use detach_project or stop_project when done',
+            ].join('\n'),
+          }],
+        };
+      }
+
+      return {
+        content: [{
+          type: 'text',
+          text: [
+            'Project attached and MCP bridge is ready.',
+            '- Runtime tools (take_screenshot, simulate_input, get_ui_elements, run_script) are available now',
+            '- get_debug_output is unavailable in attached mode because MCP did not spawn the process',
+            '- Use detach_project or stop_project when done to clean up the injected bridge state',
+          ].join('\n'),
+        }],
+      };
+    }
+
     return {
       content: [{
         type: 'text',
         text: [
           'Project attached for manual runtime use.',
-          '- Launch Godot yourself after this call so the injected McpBridge can initialize',
-          '- Runtime tools will become available once the bridge responds (typically 2–3 seconds after launch)',
+          '- Launch Godot yourself, then call attach_project again with waitForBridge: true to confirm readiness',
+          '- Or use runtime tools directly — they will fail with a clear error if the bridge is not yet listening',
           '- get_debug_output is unavailable in attached mode because MCP did not spawn the process',
           '- Use detach_project or stop_project when done to clean up the injected bridge state',
         ].join('\n'),

--- a/src/tools/project-tools.ts
+++ b/src/tools/project-tools.ts
@@ -694,19 +694,15 @@ export async function handleAttachProject(runner: GodotRunner, args: OperationPa
       const bridgeResult = await runner.waitForBridgeAttached();
 
       if (!bridgeResult.ready) {
-        return {
-          content: [{
-            type: 'text',
-            text: [
-              'Project attached but the MCP bridge did not respond within 15 seconds.',
-              '- Verify Godot is running with this project',
-              '- The McpBridge autoload must be initialized and listening on UDP port 9900',
-              '- Runtime tools may work if you retry after a moment',
-              '- get_debug_output is unavailable in attached mode',
-              '- Use detach_project or stop_project when done',
-            ].join('\n'),
-          }],
-        };
+        return createErrorResponse(
+          `Project attached but the MCP bridge is not ready.\n${bridgeResult.error || ''}`,
+          [
+            'Verify Godot is running with this project',
+            'The McpBridge autoload must be initialized and listening on UDP port 9900',
+            'Check that no other Godot project is occupying port 9900',
+            'Use detach_project or stop_project when done',
+          ]
+        );
       }
 
       return {

--- a/src/tools/project-tools.ts
+++ b/src/tools/project-tools.ts
@@ -128,7 +128,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'run_project',
-    description: 'Run a Godot project with stdout/stderr captured. Preferred path for runtime tools. Required before calling take_screenshot, simulate_input, get_ui_elements, run_script, or get_debug_output unless you intentionally use attach_project for a manually launched game. After starting, wait 2–3 seconds for the MCP bridge to initialize before using runtime tools. Call stop_project when done.',
+    description: 'Run a Godot project in debug mode. Preferred path for runtime tools. Required before calling take_screenshot, simulate_input, get_ui_elements, run_script, or get_debug_output unless you intentionally use attach_project for a manually launched game. Verifies MCP bridge readiness before returning success. Call stop_project when done.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -228,7 +228,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'take_screenshot',
-    description: 'Capture a PNG screenshot of the running Godot viewport. Requires run_project first; wait 2–3 seconds after starting for the bridge to initialize. Returns the image inline. Screenshots are also saved to .mcp/screenshots/ in the project directory.',
+    description: 'Capture a PNG screenshot of the running Godot viewport. Requires an active runtime session (run_project or attach_project). Returns the image inline. Screenshots are also saved to .mcp/screenshots/ in the project directory.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -242,7 +242,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'simulate_input',
-    description: 'Simulate batched sequential input in a running Godot project. Requires run_project first; wait 2–3 seconds after starting. Use get_ui_elements first to discover element names and paths for click_element actions.\n\nEach action object requires a "type" field. Valid types and their specific fields:\n- key: keyboard event (key: string, pressed: bool, shift/ctrl/alt: bool)\n- mouse_button: click at coordinates (x, y: number, button: "left"|"right"|"middle", pressed: bool, double_click: bool)\n- mouse_motion: move cursor (x, y: number, relative_x, relative_y: number)\n- click_element: click a UI element by node path or node name (element: string, button, double_click)\n- action: fire a Godot input action (action: string, pressed: bool, strength: 0–1)\n- wait: pause between actions (ms: number)\n\nExamples:\n1. Press and release Space: [{type:"key",key:"Space",pressed:true},{type:"wait",ms:100},{type:"key",key:"Space",pressed:false}]\n2. Click a UI button (discover path with get_ui_elements first): [{type:"click_element",element:"StartButton"}]\n3. Left-click at viewport coordinates: [{type:"mouse_button",x:400,y:300,button:"left",pressed:true},{type:"mouse_button",x:400,y:300,button:"left",pressed:false}]\n4. Fire a Godot action: [{type:"action",action:"jump",pressed:true},{type:"wait",ms:200},{type:"action",action:"jump",pressed:false}]\n5. Type "hello": [{type:"key",key:"H",pressed:true},{type:"key",key:"H",pressed:false},{type:"key",key:"E",pressed:true},{type:"key",key:"E",pressed:false},{type:"key",key:"L",pressed:true},{type:"key",key:"L",pressed:false},{type:"key",key:"L",pressed:true},{type:"key",key:"L",pressed:false},{type:"key",key:"O",pressed:true},{type:"key",key:"O",pressed:false}]',
+    description: 'Simulate batched sequential input in a running Godot project. Requires an active runtime session (run_project or attach_project). Use get_ui_elements first to discover element names and paths for click_element actions.\n\nEach action object requires a "type" field. Valid types and their specific fields:\n- key: keyboard event (key: string, pressed: bool, shift/ctrl/alt: bool)\n- mouse_button: click at coordinates (x, y: number, button: "left"|"right"|"middle", pressed: bool, double_click: bool)\n- mouse_motion: move cursor (x, y: number, relative_x, relative_y: number)\n- click_element: click a UI element by node path or node name (element: string, button, double_click)\n- action: fire a Godot input action (action: string, pressed: bool, strength: 0–1)\n- wait: pause between actions (ms: number)\n\nExamples:\n1. Press and release Space: [{type:"key",key:"Space",pressed:true},{type:"wait",ms:100},{type:"key",key:"Space",pressed:false}]\n2. Click a UI button (discover path with get_ui_elements first): [{type:"click_element",element:"StartButton"}]\n3. Left-click at viewport coordinates: [{type:"mouse_button",x:400,y:300,button:"left",pressed:true},{type:"mouse_button",x:400,y:300,button:"left",pressed:false}]\n4. Fire a Godot action: [{type:"action",action:"jump",pressed:true},{type:"wait",ms:200},{type:"action",action:"jump",pressed:false}]\n5. Type "hello": [{type:"key",key:"H",pressed:true},{type:"key",key:"H",pressed:false},{type:"key",key:"E",pressed:true},{type:"key",key:"E",pressed:false},{type:"key",key:"L",pressed:true},{type:"key",key:"L",pressed:false},{type:"key",key:"L",pressed:true},{type:"key",key:"L",pressed:false},{type:"key",key:"O",pressed:true},{type:"key",key:"O",pressed:false}]',
     inputSchema: {
       type: 'object',
       properties: {
@@ -282,7 +282,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_ui_elements',
-    description: 'Get Control nodes from a running Godot project with their positions, sizes, types, and text. Requires run_project first; wait 2–3 seconds after starting. Call this before simulate_input with click_element to discover valid element names and paths. Returns: { elements: [{ name, path, type, rect: {x,y,width,height}, visible, text? (Button/Label/LineEdit/TextEdit), disabled? (buttons), tooltip? }] }',
+    description: 'Get Control nodes from a running Godot project with their positions, sizes, types, and text. Requires an active runtime session (run_project or attach_project). Call this before simulate_input with click_element to discover valid element names and paths. Returns: { elements: [{ name, path, type, rect: {x,y,width,height}, visible, text? (Button/Label/LineEdit/TextEdit), disabled? (buttons), tooltip? }] }',
     inputSchema: {
       type: 'object',
       properties: {
@@ -601,11 +601,46 @@ export async function handleRunProject(runner: GodotRunner, args: OperationParam
     const background = args.background === true;
     runner.runProject(args.projectPath as string, args.scene as string | undefined, background);
 
+    const bridgeResult = await runner.waitForBridge();
+
+    if (!bridgeResult.ready) {
+      if (runner.activeProcess && runner.activeProcess.hasExited) {
+        return createErrorResponse(
+          `Godot process exited before the MCP bridge could initialize.\n${bridgeResult.error || ''}`,
+          [
+            'Check get_debug_output for runtime errors',
+            'Verify a display server is available (Wayland/X11)',
+            'Check for broken autoloads with list_autoloads',
+            'Call stop_project to clean up, then try again',
+          ]
+        );
+      }
+
+      const lines = [
+        'Godot process started, but the MCP bridge did not respond within 8 seconds.',
+        '- The process is running — bridge may still be initializing',
+        '- Use get_debug_output to investigate',
+        '- Runtime tools may work if you retry after a moment',
+        '- Call stop_project when done',
+      ];
+      if (background) {
+        lines.push('- Background mode: window hidden, physical input blocked');
+      }
+      return createErrorResponse(
+        lines.join('\n'),
+        [
+          'Use get_debug_output to inspect the last captured logs',
+          'Check that UDP port 9900 is not occupied by another Godot process',
+          'Call stop_project to clean up, then run_project again',
+        ]
+      );
+    }
+
     const lines = [
-      'Godot project started.',
+      'Godot project started and MCP bridge is ready.',
+      '- Runtime tools (take_screenshot, simulate_input, get_ui_elements, run_script) are available now',
       '- Use get_debug_output to check runtime output and errors',
-      '- Wait 2–3 seconds before calling take_screenshot, simulate_input, get_ui_elements, or run_script (bridge needs time to initialize)',
-      '- Always call stop_project when done — it terminates the process and cleans up the MCP bridge',
+      '- Call stop_project when done',
     ];
     if (background) {
       lines.push('- Background mode: window hidden, physical input blocked');
@@ -657,7 +692,7 @@ export async function handleAttachProject(runner: GodotRunner, args: OperationPa
         text: [
           'Project attached for manual runtime use.',
           '- Launch Godot yourself after this call so the injected McpBridge can initialize',
-          '- Wait 2–3 seconds after launch before calling take_screenshot, simulate_input, get_ui_elements, or run_script',
+          '- Runtime tools will become available once the bridge responds (typically 2–3 seconds after launch)',
           '- get_debug_output is unavailable in attached mode because MCP did not spawn the process',
           '- Use detach_project or stop_project when done to clean up the injected bridge state',
         ].join('\n'),
@@ -958,7 +993,7 @@ export async function handleTakeScreenshot(runner: GodotRunner, args: OperationP
       `Failed to take screenshot: ${errorMessage}`,
       [
         'Ensure the project is running (use run_project first)',
-        'The bridge may not be ready yet — wait 2-3 seconds after starting, then check get_debug_output if the issue persists',
+        'The bridge may not be ready yet — use get_debug_output to investigate',
         'Check that UDP port 9900 is not blocked',
       ]
     );
@@ -1031,7 +1066,7 @@ export async function handleSimulateInput(runner: GodotRunner, args: OperationPa
       `Failed to simulate input: ${errorMessage}`,
       [
         'Ensure the project is running (use run_project first)',
-        'The bridge may not be ready yet — wait 2-3 seconds after starting, then check get_debug_output if the issue persists',
+        'The bridge may not be ready yet — use get_debug_output to investigate',
         'Check that UDP port 9900 is not blocked',
       ]
     );
@@ -1090,7 +1125,7 @@ export async function handleGetUiElements(runner: GodotRunner, args: OperationPa
       `Failed to get UI elements: ${errorMessage}`,
       [
         'Ensure the project is running (use run_project first)',
-        'The bridge may not be ready yet — wait 2-3 seconds after starting, then check get_debug_output if the issue persists',
+        'The bridge may not be ready yet — use get_debug_output to investigate',
         'Check that UDP port 9900 is not blocked',
       ]
     );

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -935,6 +935,26 @@ export class GodotRunner {
     return { response, runtimeErrors };
   }
 
+  async waitForBridgeAttached(timeoutMs: number = 15000, intervalMs: number = 500): Promise<{ ready: boolean; error?: string }> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      try {
+        const response = await this.sendCommand('ping', {}, 1000);
+        const parsed = JSON.parse(response);
+        if (parsed.status === 'pong') {
+          return { ready: true };
+        }
+      } catch {
+        // Expected: ping will fail until bridge is listening
+      }
+
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+
+    return { ready: false, error: 'Bridge did not respond within timeout — is Godot running with the McpBridge autoload?' };
+  }
+
   async waitForBridge(timeoutMs: number = 8000, intervalMs: number = 300): Promise<{ ready: boolean; error?: string }> {
     const deadline = Date.now() + timeoutMs;
     const expectedToken = this.activeProcess?.sessionToken;

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -937,12 +937,19 @@ export class GodotRunner {
 
   async waitForBridgeAttached(timeoutMs: number = 15000, intervalMs: number = 500): Promise<{ ready: boolean; error?: string }> {
     const deadline = Date.now() + timeoutMs;
+    const expectedPath = this.activeProjectPath ? normalize(this.activeProjectPath) + '/' : null;
 
     while (Date.now() < deadline) {
       try {
         const response = await this.sendCommand('ping', {}, 1000);
         const parsed = JSON.parse(response);
         if (parsed.status === 'pong') {
+          if (expectedPath && parsed.project_path) {
+            const bridgePath = normalize(parsed.project_path);
+            if (bridgePath !== expectedPath) {
+              return { ready: false, error: `Bridge is running for a different project (${bridgePath}), expected ${expectedPath}` };
+            }
+          }
           return { ready: true };
         }
       } catch {

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -3,6 +3,7 @@ import { join, dirname, normalize } from 'path';
 import { existsSync, readFileSync, writeFileSync, copyFileSync, unlinkSync, mkdirSync } from 'fs';
 import { spawn, ChildProcess, SpawnOptions } from 'child_process';
 import { createSocket } from 'dgram';
+import { randomBytes } from 'crypto';
 
 // Derive __filename and __dirname in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -85,6 +86,7 @@ export interface GodotProcess {
   totalErrorsWritten: number;
   exitCode: number | null;
   hasExited: boolean;
+  sessionToken: string;
 }
 
 export type RuntimeSessionMode = 'spawned' | 'attached';
@@ -600,9 +602,13 @@ export class GodotRunner {
     }
 
     logDebug(`Running Godot project: ${projectPath}`);
-    const spawnOptions: SpawnOptions = { stdio: 'pipe' };
+    const sessionToken = randomBytes(16).toString('hex');
+    const spawnOptions: SpawnOptions = {
+      stdio: 'pipe',
+      env: { ...process.env, MCP_SESSION_TOKEN: sessionToken },
+    };
     if (background) {
-      spawnOptions.env = { ...process.env, MCP_BACKGROUND: '1' };
+      spawnOptions.env = { ...spawnOptions.env, MCP_BACKGROUND: '1' };
     }
     const proc = spawn(this.godotPath, cmdArgs, spawnOptions);
     const output: string[] = [];
@@ -615,6 +621,7 @@ export class GodotRunner {
       totalErrorsWritten: 0,
       exitCode: null,
       hasExited: false,
+      sessionToken,
     };
 
     proc.stdout?.on('data', (data: Buffer) => {
@@ -926,5 +933,46 @@ export class GodotRunner {
       ? this.extractRuntimeErrors(newErrors)
       : [];
     return { response, runtimeErrors };
+  }
+
+  async waitForBridge(timeoutMs: number = 8000, intervalMs: number = 300): Promise<{ ready: boolean; error?: string }> {
+    const deadline = Date.now() + timeoutMs;
+    const expectedToken = this.activeProcess?.sessionToken;
+
+    if (!expectedToken) {
+      return { ready: false, error: 'No active spawned Godot process to verify' };
+    }
+
+    while (Date.now() < deadline) {
+      if (this.activeProcess && this.activeProcess.hasExited) {
+        const lastErrors = this.getRecentErrors(20);
+        const errorText = lastErrors.length > 0 ? `\nLast stderr:\n${lastErrors.join('\n')}` : '';
+        return {
+          ready: false,
+          error: `Process exited with code ${this.activeProcess.exitCode} before bridge was ready.${errorText}`,
+        };
+      }
+
+      try {
+        const response = await this.sendCommand('ping', { session_token: expectedToken }, 1000);
+        const parsed = JSON.parse(response);
+        if (parsed.status === 'pong' && parsed.session_token === expectedToken) {
+          return { ready: true };
+        }
+      } catch {
+        // Expected: ping will fail until bridge is listening
+      }
+
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+
+    return { ready: false, error: 'Bridge did not respond with the expected session token within timeout' };
+  }
+
+  getRecentErrors(count: number = 20): string[] {
+    if (!this.activeProcess) return [];
+    return this.activeProcess.errors
+      .slice(-count)
+      .filter(line => line.trim() !== '');
   }
 }


### PR DESCRIPTION
  ## Summary

  - Make `run_project` wait for the injected MCP bridge to respond before reporting success
  - Validate spawned bridge readiness with a per-process session token to avoid talking to a stale Godot process on port 9900
  - Add optional `waitForBridge` support to `attach_project` for manual-launch workflows
  - Include bridge metadata in `ping` responses so callers can distinguish spawned and attached sessions
  - Replace “wait 2-3 seconds” guidance with readiness-aware success and error messages

  ## Motivation

 Runtime tools depend on the Godot-side UDP bridge being initialized. Previously, `run_project` could return before the bridge was listening, so callers had to wait an arbitrary amount of time and then discover startup failures through later runtime-tool timeouts.

 This change makes the startup contract more explicit: when `run_project` succeeds, runtime tools should be usable immediately. If Godot exits during startup or the bridge does not respond in time, callers get a direct error with recovery guidance.

For attached mode, `waitForBridge` gives callers an optional way to confirm that a manually launched Godot process has initialized the injected bridge before using runtime tools.

## Testing
There is no testing suite implemented here. No unit testing or integration tests. Have you thought about adding that? Do you mind if i look into it?
