### PR TITLE
feat: tool annotations, outputSchemas, and description improvements

### DIFF
--- a/docs/tool-authoring.md
+++ b/docs/tool-authoring.md
@@ -1,0 +1,102 @@
+# Tool Authoring Standards
+
+Standards for adding or modifying MCP tools in `godot-mcp-runtime`. Every tool ships on every client handshake — its description, schema, and annotations are the entire interface an LLM agent has to work with. Treat them like a UI, not an API doc.
+
+If you change anything in `src/tools/*.ts`, work this checklist.
+
+---
+
+## 1. Description requirements
+
+Every tool description states, in this order:
+
+1. **Purpose** — what the tool does, in one sentence, in the agent's vocabulary (the outcome it achieves), not the implementation.
+2. **Behavior** — non-obvious side effects. Especially: auto-save behavior, overwrite policy, what happens when the target doesn't exist.
+3. **Parameter intent** — anything the schema can't express. Defaults, conditional requirements, parameter interactions, auto-conversions (e.g. Vector2/Color from `{x, y}` / `{r, g, b, a}`).
+4. **Returns** — explicit return shape. Either an `outputSchema` field, or a `Returns: { … }` line in the description. Never both ambiguous.
+5. **Use when / prefer X when** — when an agent should pick this tool over a sibling. Especially important when the server has multiple tools that touch the same resource.
+6. **Error disclosure** — one short line per likely failure mode. "Errors if node not found." / "Overwrites silently." / "Returns empty array on no match."
+
+### Description size budget
+
+Soft cap **~500 characters per tool** including newlines. Every tool description ships on every handshake; bloat directly steals from the agent's context budget. If a description grows beyond this, pull background into a `# Notes` section in `docs/tools.md` and link.
+
+### Examples in descriptions
+
+Examples are useful but **contracts**: an example with two array items will produce two-item arrays. Use sparingly; if you must show one, make it minimal and not representative of common usage.
+
+---
+
+## 2. MCP annotations
+
+Every tool definition includes an `annotations` object. Pick from:
+
+| Annotation        | When to set `true`                                                                                                        |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `readOnlyHint`    | Tool only reads state, never mutates files, project, or running process.                                                  |
+| `destructiveHint` | Tool removes or replaces something hard to recover.                                                                       |
+| `idempotentHint`  | Calling N times with the same args produces the same result as calling once. Setters with absolute values, not appenders. |
+
+Defaults: omit annotations only if none apply. `readOnlyHint` and `destructiveHint` should be mutually exclusive.
+
+Why this matters: clients ask for extra confirmation when a tool lacks a `readOnlyHint`. Setting these correctly improves the agent's experience without changing the tool itself.
+
+---
+
+## 3. `outputSchema`
+
+Add an `outputSchema` field when the return shape is non-trivial — anything richer than a simple success/error string. JSON Schema, same shape as `inputSchema`.
+
+If `outputSchema` is impractical (highly variable shape), document the return inline with a `Returns: { … }` line in the description. Don't leave reviewers and agents to guess.
+
+---
+
+## 4. Naming convention
+
+**Verb plurality matches param cardinality.**
+
+- Singular subject → singular verb: `add_node({ nodeType, nodeName, ... })`, `attach_script({ nodePath, scriptPath })`
+- Array subject → plural verb: `set_node_properties({ updates: [...] })`, `delete_nodes({ nodePaths: [...] })`, `get_node_properties({ nodes: [...] })`
+
+The `batch_` prefix is **not** a naming convention — it's the symptom of a missed consolidation (see §5). If you're tempted to add `batch_foo`, reconsider whether `foos` should take an array.
+
+Use snake_case for tool names and the GDScript boundary; camelCase inside TypeScript. The `normalizeParameters` / `convertCamelToSnakeCase` helpers in `godot-runner.ts` bridge them.
+
+---
+
+## 5. Consolidation criteria
+
+**Decompose by outcome, not by parity with the underlying API.**
+
+| Situation                                                              | Pattern                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Same outcome, varying cardinality (set property on 1 node vs 50 nodes) | **One tool, array param.** `set_node_properties({ updates: [...] })`. An LLM passing a 1-element array is trivial.                                                                                                                                                                                                                                                                                                                           |
+| Different outcomes (delete a node vs duplicate a node)                 | **Separate tools.** Different verbs, different shapes.                                                                                                                                                                                                                                                                                                                                                                                       |
+| Heterogeneous ordered operations on shared state in one process        | **One tool with per-item operation field is acceptable** if the discriminator is load-bearing — dropping it would force agents to chain N round-trips and lose the shared-state guarantee. `batch_scene_operations` is the documented exception in this server: the alternative (N singular calls) costs ~3s startup per call and loses the in-process scene cache. **Rare.** Never use as an escape hatch from designing per-outcome tools. |
+| Read-only diagnostic that agents almost never need                     | **Drop it.** Don't keep low-value tools in the surface "in case." Every tool ships on every handshake.                                                                                                                                                                                                                                                                                                                                       |
+
+### Discriminator antipattern: how to recognize it
+
+If your tool's `inputSchema` has:
+
+- A field whose enum value gates which other fields are required, AND
+- The valid-params-per-enum-value relationship is documented in description text, not enforced by schema
+
+…you have a discriminator antipattern. Agents can't reliably reason about which params are valid given which operation value, and conditional schemas double the validation surface. Either split into separate tools (preferred) or document why the discriminator is load-bearing and the cost of splitting (see `batch_scene_operations`).
+
+---
+
+## 6. Pre-merge checklist
+
+For any PR that adds or changes a tool definition:
+
+- [ ] Description includes purpose, behavior, params intent, returns, "use when", error disclosure (§1)
+- [ ] Description under ~500 chars (§1)
+- [ ] `annotations` set correctly: `readOnlyHint` / `destructiveHint` / `idempotentHint` (§2)
+- [ ] `outputSchema` present, OR description has explicit `Returns: { … }` line (§3)
+- [ ] Tool name follows verb-plurality rule (§4); no new `batch_*` unless §5 exception applies
+- [ ] Consolidation check: is there already a sibling tool with the same outcome at different cardinality? If so, fold (§5)
+- [ ] If discriminator: documented as load-bearing exception with rationale (§5)
+- [ ] `docs/tools.md` updated with the new/changed tool entry
+- [ ] If breaking (rename, drop, schema change): migration table entry in CHANGELOG / release notes
+- [ ] `npm run verify` passes (typecheck → lint → format:check → test → build)

--- a/src/tools/node-tools.ts
+++ b/src/tools/node-tools.ts
@@ -15,7 +15,9 @@ import {
 export const nodeToolDefinitions: ToolDefinition[] = [
   {
     name: 'delete_node',
-    description: 'Remove a node from a Godot scene file. Saves automatically.',
+    description:
+      'Remove a node and all its children from a Godot scene file. Use when pruning the scene tree; for replacing a node in place, pair with add_node. Saves automatically. Cannot delete the scene root. Errors if nodePath does not exist. Returns { success, nodePath }.',
+    annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -35,7 +37,8 @@ export const nodeToolDefinitions: ToolDefinition[] = [
   {
     name: 'set_node_property',
     description:
-      'Set a property on a node in a Godot scene file. Saves automatically. Primitives (string, number, boolean, array, object) are passed as-is. Vector2 ({"x","y"}), Vector3 ({"x","y","z"}), and Color ({"r","g","b","a"}) are automatically converted. Use run_script for other complex GDScript types.',
+      'Set a single property on a node in a Godot scene file. For multiple properties on the same or different nodes, use batch_set_node_properties — one Godot process instead of N. Saves automatically. Primitives pass through; Vector2 ({x,y}), Vector3 ({x,y,z}), and Color ({r,g,b,a}) auto-convert. For other complex GDScript types (Resource, NodePath, etc.), use run_script. Errors if nodePath or property does not exist. Returns { success, nodePath, property }.',
+    annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -55,7 +58,8 @@ export const nodeToolDefinitions: ToolDefinition[] = [
   {
     name: 'batch_set_node_properties',
     description:
-      'Set multiple node properties in a single Godot process. Saves automatically. Returns { results: [{ nodePath, property, success?, error? }] }.',
+      'Set multiple node properties in a single Godot process — preferred over chained set_node_property calls (avoids ~3s startup per call). Same value-conversion rules as set_node_property. abortOnError stops on first failure (default false continues). Saves once at the end. Returns { results: [{ nodePath, property, success?, error? }] }.',
+    annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -84,7 +88,9 @@ export const nodeToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'get_node_properties',
-    description: "Read a node's current property values from a Godot scene file.",
+    description:
+      "Read a node's current property values from a scene file. For multiple nodes, use batch_get_node_properties (one process). changedOnly:true filters out properties matching their class defaults — useful for compact diffs. Errors if nodePath does not exist. Returns { nodePath, nodeType, properties: { [key]: value } }.",
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -103,7 +109,8 @@ export const nodeToolDefinitions: ToolDefinition[] = [
   {
     name: 'batch_get_node_properties',
     description:
-      'Get properties from multiple nodes in a single Godot process. Returns { results: [{ nodePath, nodeType, properties?, error? }] }.',
+      'Get properties from multiple nodes in a single Godot process — preferred over chained get_node_properties calls. Per-node changedOnly toggles default-filtering individually. Returns { results: [{ nodePath, nodeType, properties?, error? }] }; failed reads include error and omit properties.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -130,7 +137,9 @@ export const nodeToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'attach_script',
-    description: 'Attach a GDScript file to a node in a Godot scene. Saves automatically.',
+    description:
+      'Attach an existing GDScript file to a node in a scene. Use after writing the script with the standard file tools and validating it via the validate tool. Replaces any previously attached script. Saves automatically. Errors if scriptPath does not exist or nodePath is not found. Returns { success, nodePath, scriptPath }.',
+    annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -149,7 +158,8 @@ export const nodeToolDefinitions: ToolDefinition[] = [
   {
     name: 'get_scene_tree',
     description:
-      'Get the scene hierarchy as a tree structure. Use maxDepth: 1 for a shallow listing of direct children only.',
+      'Get the scene hierarchy as a nested tree of { name, type, path, children }. Use maxDepth:1 for a shallow listing of direct children only; default -1 returns the full tree. parentPath scopes the result to a subtree. Errors if scene does not exist or parentPath is not found.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -170,7 +180,8 @@ export const nodeToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'duplicate_node',
-    description: 'Duplicate a node and its children in a Godot scene. Saves automatically.',
+    description:
+      'Duplicate a node and its descendants in a Godot scene. Use to clone a configured subtree without re-creating it node-by-node via add_node. newName defaults to the original name + "2"; targetParentPath defaults to the original parent. Saves automatically. Errors if nodePath does not exist or targetParentPath cannot accept children. Returns { success, originalPath, newPath }.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -192,7 +203,8 @@ export const nodeToolDefinitions: ToolDefinition[] = [
   {
     name: 'get_node_signals',
     description:
-      'List all signals defined on a node and their current connections. Returns { nodePath, nodeType, signals: [{ name, connections: [{ signal, target, method }] }] }. Note: the target field uses Godot absolute path format (e.g. /root/Scene/Node) — convert to scene-root-relative (e.g. root/Node) before passing to connect_signal or disconnect_signal.',
+      'List all signals defined on a node and their current connections. Use before connect_signal/disconnect_signal to verify signal/method names. Returns { nodePath, nodeType, signals: [{ name, connections: [{ signal, target, method }] }] }. The target field uses Godot absolute path format (/root/Scene/Node) — convert to scene-root-relative (root/Node) before passing to connect/disconnect_signal. Errors if node not found.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/tools/project-tools.ts
+++ b/src/tools/project-tools.ts
@@ -133,7 +133,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'launch_editor',
     description:
-      'Open the Godot editor GUI for a project. The editor is a display application — it cannot be controlled programmatically and returns immediately. For headless project modification, use the scene and node editing tools (add_node, set_node_property, etc.) instead.',
+      'Open the Godot editor GUI for a project for the human user. Use only when the user explicitly asks to "open the editor"; for any agent-driven work, use the headless scene/node tools (add_node, set_node_property, etc.) instead — the editor cannot be controlled programmatically. Returns immediately after spawning. Errors if projectPath has no project.godot.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -148,7 +148,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'run_project',
     description:
-      'Run a Godot project with stdout/stderr captured. Preferred path for runtime tools. Required before calling take_screenshot, simulate_input, get_ui_elements, run_script, or get_debug_output unless you intentionally use attach_project for a manually launched game. Verifies MCP bridge readiness before returning success. Call stop_project when done.',
+      'Spawn a Godot project as a child process with stdout/stderr captured. This is the preferred entry to runtime tools — use whenever MCP can launch the game itself. Required before take_screenshot, simulate_input, get_ui_elements, run_script, or get_debug_output. For a Godot process you launched yourself (debugger attached, custom flags, IDE run), use attach_project instead. Verifies MCP bridge readiness before returning success. Call stop_project when done. Errors if projectPath is not a Godot project or another run is already active.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -173,7 +173,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'attach_project',
     description:
-      'Attach runtime MCP tools to a project without spawning Godot. This injects the McpBridge autoload and marks the project as the active runtime session so you can launch the game manually from your own shell, then use take_screenshot, simulate_input, get_ui_elements, and run_script against that running game. Set waitForBridge to true after launching Godot to block until the bridge is confirmed ready. Use detach_project or stop_project when done. get_debug_output is not available in attached mode because stdout/stderr are not captured.',
+      'Attach runtime MCP tools to a manually launched Godot process without spawning one. Use this only when the user is running Godot themselves (debugger attached, custom CLI flags, IDE run) — for the standard case, use run_project. Injects the McpBridge autoload and marks the project active. Call once before launching Godot, then again with waitForBridge:true after launch to confirm the bridge is listening (up to 15s). Use detach_project or stop_project when done. get_debug_output is unavailable in attached mode (stdout/stderr not captured).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -193,7 +193,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'detach_project',
     description:
-      'Clear attached-mode runtime state and remove the injected McpBridge autoload without claiming that the manually launched Godot process was stopped.',
+      'Clear attached-mode runtime state and remove the injected McpBridge autoload. Does NOT stop the manually launched Godot process — that stays running. Use after attach_project when you are done driving the game from MCP. For spawned sessions (run_project), use stop_project instead. No-op if no attached session exists.',
+    annotations: { destructiveHint: true, idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {},
@@ -203,7 +204,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'get_debug_output',
     description:
-      'Get stdout/stderr output from the running Godot project. Requires run_project first. Returns the last N lines of output and errors, a running flag, and an exit code if the process has ended. In attached mode, this reports that stdout/stderr capture is unavailable because Godot was launched outside MCP.',
+      'Get captured stdout/stderr from a spawned Godot project. Use whenever runtime tools fail unexpectedly — script errors, missing nodes, and crash backtraces all surface here. Requires run_project (not attach_project; attached mode does not capture output). Returns { output, errors, running, exitCode? } with the last `limit` lines (default 200, from the end). Reports attached-mode unavailability gracefully.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -218,7 +220,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'stop_project',
     description:
-      'Stop the running Godot project and clean up the MCP bridge. Always call this when done with runtime testing — even if the game crashed — to free the process slot so run_project can be called again.',
+      'Stop the spawned Godot project and clean up MCP bridge state. Always call when done with runtime testing — even after a crash — to free the single process slot so run_project can be called again. For attached sessions, this detaches without killing the externally launched process. No-op if no session is active.',
+    annotations: { destructiveHint: true, idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {},
@@ -227,7 +230,9 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'list_projects',
-    description: 'List Godot projects in a directory',
+    description:
+      'Find Godot projects under a directory by locating project.godot files. Use to discover available projects when the user has not specified one; for inspecting a known project, use get_project_info. recursive:true descends into subdirectories (skipping hidden ones); default false checks only the directory itself and its immediate children. Returns { projects: [{ path, name }] }, empty array on no matches.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -246,7 +251,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'get_project_info',
     description:
-      'Retrieve metadata about a Godot project, or just the Godot version if no projectPath is provided',
+      'Get metadata about a Godot project: name, path, Godot version, and a structure summary (counts of scenes/scripts/assets/other). Omit projectPath to get just the Godot version (useful for capability checks). Returns { name, path, godotVersion, structure } or { godotVersion } when projectPath is omitted. Errors if projectPath is set but lacks project.godot.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -262,7 +268,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'take_screenshot',
     description:
-      'Capture a PNG screenshot of the running Godot viewport. Requires an active runtime session (run_project or attach_project). Returns the image inline. Screenshots are also saved to .mcp/screenshots/ in the project directory.',
+      'Capture a PNG screenshot of the running Godot viewport. Use after simulate_input or run_script to verify visual changes. Requires an active runtime session (run_project or attach_project). Returns the image inline as base64. Also saved to .mcp/screenshots/ in the project directory for later reference. Errors if no session is active or the bridge does not respond within timeout (default 10000ms).',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -277,7 +284,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'simulate_input',
     description:
-      'Simulate batched sequential input in a running Godot project. Requires an active runtime session (run_project or attach_project). Use get_ui_elements first to discover element names and paths for click_element actions.\n\nEach action object requires a "type" field. Valid types and their specific fields:\n- key: keyboard event (key: string, pressed: bool, shift/ctrl/alt: bool)\n- mouse_button: click at coordinates (x, y: number, button: "left"|"right"|"middle", pressed: bool, double_click: bool)\n- mouse_motion: move cursor (x, y: number, relative_x, relative_y: number)\n- click_element: click a UI element by node path or node name (element: string, button, double_click)\n- action: fire a Godot input action (action: string, pressed: bool, strength: 0–1)\n- wait: pause between actions (ms: number)\n\nExamples:\n1. Press and release Space: [{type:"key",key:"Space",pressed:true},{type:"wait",ms:100},{type:"key",key:"Space",pressed:false}]\n2. Click a UI button (discover path with get_ui_elements first): [{type:"click_element",element:"StartButton"}]\n3. Left-click at viewport coordinates: [{type:"mouse_button",x:400,y:300,button:"left",pressed:true},{type:"mouse_button",x:400,y:300,button:"left",pressed:false}]\n4. Fire a Godot action: [{type:"action",action:"jump",pressed:true},{type:"wait",ms:200},{type:"action",action:"jump",pressed:false}]\n5. Type "hello": [{type:"key",key:"H",pressed:true},{type:"key",key:"H",pressed:false},{type:"key",key:"E",pressed:true},{type:"key",key:"E",pressed:false},{type:"key",key:"L",pressed:true},{type:"key",key:"L",pressed:false},{type:"key",key:"L",pressed:true},{type:"key",key:"L",pressed:false},{type:"key",key:"O",pressed:true},{type:"key",key:"O",pressed:false}]',
+      'Simulate batched sequential input in a running Godot project. Requires an active runtime session (run_project or attach_project). Use get_ui_elements first to discover element names and paths for click_element actions.\n\nEach action object requires a "type" field. Valid types and their specific fields:\n- key: keyboard event (key: string, pressed: bool, shift/ctrl/alt: bool)\n- mouse_button: click at coordinates (x, y: number, button: "left"|"right"|"middle", pressed: bool, double_click: bool)\n- mouse_motion: move cursor (x, y: number, relative_x, relative_y: number)\n- click_element: click a UI element by node path or node name (element: string, button, double_click)\n- action: fire a Godot input action (action: string, pressed: bool, strength: 0–1)\n- wait: pause between actions (ms: number)\n\nExamples:\n1. Press and release Space: [{type:"key",key:"Space",pressed:true},{type:"wait",ms:100},{type:"key",key:"Space",pressed:false}]\n2. Click a UI button (discover path with get_ui_elements first): [{type:"click_element",element:"StartButton"}]\n3. Left-click at viewport coordinates: [{type:"mouse_button",x:400,y:300,button:"left",pressed:true},{type:"mouse_button",x:400,y:300,button:"left",pressed:false}]\n4. Fire a Godot action: [{type:"action",action:"jump",pressed:true},{type:"wait",ms:200},{type:"action",action:"jump",pressed:false}]\n5. Type "hello": [{type:"key",key:"H",pressed:true},{type:"key",key:"H",pressed:false},{type:"key",key:"E",pressed:true},{type:"key",key:"E",pressed:false},{type:"key",key:"L",pressed:true},{type:"key",key:"L",pressed:false},{type:"key",key:"L",pressed:true},{type:"key",key:"L",pressed:false},{type:"key",key:"O",pressed:true},{type:"key",key:"O",pressed:false}]\n\nReturns { success, actions_processed, warnings? }. Errors if no runtime session is active.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -359,7 +366,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'get_ui_elements',
     description:
-      'Get Control nodes from a running Godot project with their positions, sizes, types, and text. Requires an active runtime session (run_project or attach_project). Call this before simulate_input with click_element to discover valid element names and paths. Returns: { elements: [{ name, path, type, rect: {x,y,width,height}, visible, text? (Button/Label/LineEdit/TextEdit), disabled? (buttons), tooltip? }] }',
+      'Walk the running scene tree and return all Control nodes with positions, sizes, types, and text content. Always call this before simulate_input click_element actions to discover valid element names and paths. Requires an active runtime session (run_project or attach_project). visibleOnly defaults true; pass false to include hidden Controls. filter narrows by class. Returns { elements: [{ name, path, type, rect, visible, text?, disabled?, tooltip? }] }.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -399,7 +407,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'list_autoloads',
     description:
-      'List all registered autoloads in a Godot project with paths and singleton status. No Godot process required — reads project.godot directly.',
+      'List all registered autoloads in a project with paths and singleton status. Use first when diagnosing headless failures — broken autoloads crash all headless ops, so this tells you what is loaded. No Godot process required (reads project.godot directly). Returns { autoloads: [{ name, path, singleton }] }.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -411,7 +420,7 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'add_autoload',
     description:
-      'Register a new autoload in a Godot project. No Godot process required. Warning: autoloads initialize in headless mode — if the script has errors, all headless operations will fail.',
+      'Register a new autoload in a project. autoloadPath accepts "res://..." or a project-relative path (auto-prefixed). singleton defaults true (accessible globally by name). No Godot process required. Warning: autoloads initialize in headless mode — a broken script will crash every subsequent headless op; validate before adding. Errors if an autoload with the same name already exists; use update_autoload to modify.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -435,7 +444,9 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'remove_autoload',
-    description: 'Unregister an autoload from a Godot project by name. No Godot process required.',
+    description:
+      'Unregister an autoload from a project by name. Use to recover from a broken autoload that is crashing headless ops. No Godot process required. Errors if no autoload with that name exists.',
+    annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -447,7 +458,9 @@ export const projectToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'update_autoload',
-    description: "Modify an existing autoload's path or singleton flag. No Godot process required.",
+    description:
+      "Modify an existing autoload's path or singleton flag. Pass either or both — omitted fields keep their current value. Use instead of remove_autoload + add_autoload (single edit, no orphan window). No Godot process required. Errors if autoloadName is not registered.",
+    annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -462,7 +475,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'get_project_files',
     description:
-      'Return a recursive file tree of a Godot project. Skips hidden (dot-prefixed) entries and the .mcp directory. Returns nested { name, type, path, extension?, children? } objects.',
+      'Return a recursive file tree of a Godot project as nested { name, type, path, extension?, children? } objects. Use to discover project structure when paths are unknown. Pass extensions to filter (e.g. ["gd","tscn"]); maxDepth caps recursion (-1 unlimited). Skips hidden (dot-prefixed) entries and the .mcp directory.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -484,7 +498,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'search_project',
     description:
-      'Plain-text search across project files. Returns { matches: [{ file, lineNumber, line }], truncated }. Skips hidden entries and the .mcp directory.',
+      'Plain-text (substring) search across project files. Use to find references, callers, or signatures across the codebase. Default fileTypes is ["gd","tscn","cs","gdshader"]; caseSensitive default false; maxResults default 100 (truncated:true if hit). Returns { matches: [{ file, lineNumber, line }], truncated }. Skips hidden entries and the .mcp directory.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -504,7 +519,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'get_scene_dependencies',
     description:
-      'Parse a .tscn file for ext_resource references (scripts, textures, subscenes). Returns { scene, dependencies: [{ path, type, uid? }] }.',
+      'Parse a .tscn file for ext_resource references (scripts, textures, subscenes). Use to inspect what a scene depends on before refactoring or moving files. Returns { scene, dependencies: [{ path, type, uid? }] }. Errors if scene file does not exist.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -521,7 +537,8 @@ export const projectToolDefinitions: ToolDefinition[] = [
   {
     name: 'get_project_settings',
     description:
-      'Parse project.godot into structured JSON. Returns { settings: { [section]: { [key]: value } } }. Complex Godot types are returned as raw strings. Keys not under any section appear under __global__.',
+      'Parse project.godot into structured JSON. Use to inspect configured display, input, rendering, etc. settings without launching Godot. Pass section to filter to one INI section (e.g. "display", "application"). Returns { settings: { [section]: { [key]: value } } } or { settings: { [key]: value } } when section is given. Complex Godot types are returned as raw strings; keys outside any section appear under __global__.',
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/tools/scene-tools.ts
+++ b/src/tools/scene-tools.ts
@@ -14,7 +14,9 @@ import {
 export const sceneToolDefinitions: ToolDefinition[] = [
   {
     name: 'create_scene',
-    description: 'Create a new Godot scene file. Saves automatically.',
+    description:
+      'Create a new Godot scene file with a single root node. Writes a fresh .tscn at scenePath. Use when starting a new scene from scratch; for adding nodes to an existing scene, use add_node. rootNodeType defaults to Node2D — pass "Node3D" for 3D scenes or "Control" for UI. Saves automatically. Overwrites silently if the file already exists. Returns { success, scenePath } as JSON text.',
+    annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -27,11 +29,18 @@ export const sceneToolDefinitions: ToolDefinition[] = [
       },
       required: ['projectPath', 'scenePath'],
     },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean' },
+        scenePath: { type: 'string' },
+      },
+    },
   },
   {
     name: 'add_node',
     description:
-      'Add a node to a Godot scene. Saves automatically. Common spatial properties can be set directly as top-level params. For other properties, use the properties dict.',
+      'Add a node to a Godot scene. Saves automatically. Common spatial properties (position, position3d, rotation, scale, visible, modulate) can be set as top-level params; for any other property, pass it under properties. Vector2/Vector3/Color values auto-convert from {x,y}/{x,y,z}/{r,g,b,a}. parentNodePath defaults to the scene root. Errors if nodeType is not a registered Godot class or parentNodePath does not exist.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -90,7 +99,8 @@ export const sceneToolDefinitions: ToolDefinition[] = [
   {
     name: 'load_sprite',
     description:
-      'Set the texture on a Sprite2D, Sprite3D, or TextureRect node. Saves automatically.',
+      'Set the texture on an existing Sprite2D, Sprite3D, or TextureRect node. Use this when the node already exists; for new nodes, pass texture via add_node properties. Saves automatically. texturePath must be a real file under projectPath. Errors if the node is not one of those three classes, or the texture file does not exist.',
+    annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -112,7 +122,8 @@ export const sceneToolDefinitions: ToolDefinition[] = [
   {
     name: 'save_scene',
     description:
-      'Re-pack and save a scene, optionally to a different path (save-as). Most mutations auto-save, so this is only needed for save-as (newPath) or to re-canonicalize a .tscn file.',
+      'Re-pack and save a scene, optionally to a different path (save-as). Most mutations (add_node, set_node_properties, delete_nodes, etc.) auto-save — only use this for save-as via newPath, or to re-canonicalize a hand-edited .tscn. Overwrites silently. Errors if the scene file does not exist.',
+    annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
       properties: {
@@ -129,7 +140,8 @@ export const sceneToolDefinitions: ToolDefinition[] = [
   },
   {
     name: 'export_mesh_library',
-    description: 'Export a scene as a MeshLibrary .res file for use in GridMap.',
+    description:
+      'Export a scene of MeshInstance3D nodes as a MeshLibrary .res file for use in GridMap. Use this when authoring tile palettes for grid-based 3D levels; ignore for 2D or general scene work. The source scene must contain MeshInstance3D children. Pass meshItemNames to export a subset, or omit to export all. Saves the .res to outputPath, overwriting silently. Errors if the scene contains no valid meshes.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -151,7 +163,7 @@ export const sceneToolDefinitions: ToolDefinition[] = [
   {
     name: 'batch_scene_operations',
     description:
-      'Execute multiple scene operations in a single Godot process. All mutations auto-save at the end. Use an explicit save op only for save-as (newPath). Returns { results: [{ operation, scenePath, success?, error? }] }.',
+      'Use this instead of chaining add_node / load_sprite / save_scene calls when you have multiple mutations on the same or related scenes — runs in one Godot process (~3s startup avoided per call) and shares an in-memory scene cache, saving once at the end. Each item picks its sub-operation (add_node, load_sprite, save) and supplies its own params; abortOnError stops on first failure (default false continues). Returns { results: [{ operation, scenePath, success?, error? }] }.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -200,7 +212,7 @@ export const sceneToolDefinitions: ToolDefinition[] = [
   {
     name: 'manage_uids',
     description:
-      'Manage resource UIDs in a Godot 4.4+ project. Requires Godot 4.4 or later.\n\nOperations:\n- get: Get the UID string for a specific file (required: filePath)\n- update: Resave all project resources to regenerate UID references (use after reorganizing files)',
+      'Manage resource UIDs in a Godot 4.4+ project. Operations: get (UID for a specific file; requires filePath) | update (resave all project resources to regenerate UID references after reorganizing files). Errors on Godot < 4.4 or invalid operation.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/tools/validate-tools.ts
+++ b/src/tools/validate-tools.ts
@@ -13,7 +13,8 @@ export const validateToolDefinitions: ToolDefinition[] = [
   {
     name: 'validate',
     description:
-      "Validate GDScript syntax or scene file integrity using headless Godot. Returns { valid, errors: [{ line?, message }] } — line numbers are present when Godot's error output includes them, which is not always the case. If valid is false, fix the reported errors and re-validate before calling attach_script or run_script.\n\nSingle-target: provide exactly one of scriptPath, source, or scenePath.\nBatch: provide a targets array where each item has one of { scriptPath, source, scenePath }. Runs all targets in a single Godot process. Returns { results: [{ target, valid, errors }] }.",
+      "Validate GDScript syntax or scene file integrity using headless Godot. Use before attach_script or run_script to catch parse errors early. Single-target: provide exactly one of scriptPath, source, or scenePath. Batch: provide a targets array — runs all in one Godot process. Returns { valid, errors: [{ line?, message }] } for single, or { results: [{ target, valid, errors }] } for batch. Line numbers appear when Godot's stderr includes them (not always). Returns valid:false on any parse error; never throws.",
+    annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -130,6 +130,14 @@ export interface OperationResult {
   stderr: string;
 }
 
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+  title?: string;
+}
+
 export interface ToolDefinition {
   name: string;
   description: string;
@@ -138,6 +146,12 @@ export interface ToolDefinition {
     properties: Record<string, unknown>;
     required: string[];
   };
+  outputSchema?: {
+    type: string;
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  annotations?: ToolAnnotations;
 }
 
 // Parameter mappings between snake_case and camelCase


### PR DESCRIPTION
## Summary

Non-breaking polish on every tool definition, in line with the new authoring standards in `docs/tool-authoring.md`.

- Adds MCP `annotations` (`readOnlyHint` / `destructiveHint` / `idempotentHint`) on every applicable tool.
- Adds `outputSchema` for tools with non-trivial return shapes; adds `Returns: { … }` lines elsewhere.
- Rewrites every tool description against the §1 checklist: purpose, behavior, parameter intent, returns, "use when" guidance, and one-line error disclosure.
- Disambiguates `run_project` vs `attach_project` so agents pick the right one.
- Extends `ToolDefinition` to type the new optional `annotations` and `outputSchema` fields.

No tool names, schemas, or runtime behavior change. The dispatch surface is identical.

## Test plan

- [x] `npm run verify` passes (typecheck → lint → format:check → test → build) on Node 20/22/24
- [x] No new tests required — existing dispatch parity test in `tests/unit/mcp-dispatch.test.ts` covers the surface
- [x] CI green on push