### PR TITLE
feat: add compact screenshot response modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each tool teaches agents how to use it through its description and response mess
 
 **Runtime bridge.** When `run_project` or `attach_project` is called, the server injects `McpBridge` as an autoload. This opens a TCP listener on port 9900 (localhost only, override with `MCP_BRIDGE_PORT`) and enables:
 
-- **Screenshots:** Capture the viewport at any point during gameplay
+- **Screenshots:** Capture the viewport at any point during gameplay, with full, preview, or path-only responses
 - **Input simulation:** Batched sequences of key presses, mouse clicks, mouse motion, UI element clicks by name or path, Godot action events, and timed waits
 - **UI discovery:** Walk the live scene tree and collect every visible Control node with its position, type, text content, and disabled state
 - **Live script execution:** Compile and run arbitrary GDScript with full SceneTree access while the game is running
@@ -160,6 +160,28 @@ When `run_project` or `attach_project` is called:
 5. `stop_project` or `detach_project` sends a `shutdown` command (so the bridge releases the port cleanly), then removes the bridge script and autoload entry
 
 Files generated during runtime (screenshots, executed scripts) are stored in `.mcp/` inside the project directory. This directory is automatically added to `.gitignore` and has a `.gdignore` so Godot won't import it.
+
+`take_screenshot` defaults to returning the full PNG inline for compatibility. Pass `responseMode: "preview"` to keep the full screenshot on disk while returning a smaller inline preview, or `responseMode: "path_only"` when the caller only needs the saved file path.
+
+Choose the smallest screenshot response that fits the task:
+
+- Use `responseMode: "preview"` for routine visual verification after input, scene changes, or live scripts. This keeps the original full-size PNG on disk and returns a 960x540-bounded preview inline by default.
+- Use `responseMode: "full"` when the agent needs to inspect exact pixels, small UI text, texture details, or other high-resolution evidence inline.
+- Use `responseMode: "path_only"` when another tool, script, or human will inspect the saved screenshot file and the MCP response only needs the path metadata.
+
+Examples:
+
+```json
+{ "responseMode": "preview" }
+```
+
+```json
+{ "responseMode": "preview", "previewMaxWidth": 480, "previewMaxHeight": 270 }
+```
+
+```json
+{ "responseMode": "path_only" }
+```
 
 ## Acknowledgments
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -19,12 +19,14 @@ The full MCP tool reference for `godot-mcp-runtime`. This file always reflects `
 
 Both `run_project` and `attach_project` wait for the bridge before returning success, so runtime tools are usable immediately after the call returns. `attach_project` waits up to 15 s for the externally launched Godot process to come up. If you (the agent) are launching Godot yourself, kick the launch off in parallel with `attach_project` so the wait absorbs Godot's startup — don't sequentialize. If a human is launching Godot and they don't make it inside the window, retry `attach_project` (`bridge.inject` is idempotent).
 
-| Tool              | Description                                                      |
-| ----------------- | ---------------------------------------------------------------- |
-| `take_screenshot` | Capture a PNG of the running viewport                            |
-| `simulate_input`  | Send batched input: key, mouse, click_element, action, wait      |
-| `get_ui_elements` | Get all visible Control nodes with positions, types, and text    |
-| `run_script`      | Execute arbitrary GDScript at runtime with full SceneTree access |
+| Tool              | Description                                                                                        |
+| ----------------- | -------------------------------------------------------------------------------------------------- |
+| `take_screenshot` | Capture a PNG of the running viewport; use `responseMode: "preview"` for token-sensitive workflows |
+| `simulate_input`  | Send batched input: key, mouse, click_element, action, wait                                        |
+| `get_ui_elements` | Get all visible Control nodes with positions, types, and text                                      |
+| `run_script`      | Execute arbitrary GDScript at runtime with full SceneTree access                                   |
+
+`take_screenshot` defaults to the full inline PNG for compatibility. Pass `responseMode: "preview"` to keep the original screenshot on disk while returning a bounded preview inline, or `responseMode: "path_only"` when the caller only needs saved-path metadata.
 
 ## Scene Editing (headless)
 

--- a/src/scripts/mcp_bridge.gd
+++ b/src/scripts/mcp_bridge.gd
@@ -160,7 +160,7 @@ func _dispatch_command(peer: PeerState, data: String) -> void:
 		"run_script":
 			await _handle_run_script(peer, payload)
 		"screenshot":
-			await _handle_screenshot(peer)
+			await _handle_screenshot(peer, payload)
 		"shutdown":
 			await _handle_shutdown(peer)
 		"ping":
@@ -170,7 +170,7 @@ func _dispatch_command(peer: PeerState, data: String) -> void:
 
 # --- Screenshot ---
 
-func _handle_screenshot(peer: PeerState) -> void:
+func _handle_screenshot(peer: PeerState, payload: Dictionary = {}) -> void:
 	await RenderingServer.frame_post_draw
 
 	var viewport := get_viewport()
@@ -183,7 +183,7 @@ func _handle_screenshot(peer: PeerState) -> void:
 		_send_response(peer, {"error": "Failed to capture viewport image"})
 		return
 
-	var timestamp := str(Time.get_unix_time_from_system()).replace(".", "_")
+	var timestamp := "%s_%d" % [str(Time.get_unix_time_from_system()).replace(".", "_"), Time.get_ticks_msec()]
 	var screenshot_dir := ProjectSettings.globalize_path("res://.mcp/screenshots")
 	DirAccess.make_dir_recursive_absolute(screenshot_dir)
 	var file_path := screenshot_dir.path_join("screenshot_%s.png" % timestamp)
@@ -194,7 +194,36 @@ func _handle_screenshot(peer: PeerState) -> void:
 		return
 
 	var safe_path := file_path.replace("\\", "/")
-	_send_response(peer, {"path": safe_path})
+	var response: Dictionary = {
+		"path": safe_path,
+		"width": image.get_width(),
+		"height": image.get_height(),
+	}
+
+	var preview_max_width: int = int(payload.get("preview_max_width", 0))
+	var preview_max_height: int = int(payload.get("preview_max_height", 0))
+	if preview_max_width > 0 and preview_max_height > 0:
+		var scale: float = min(
+			1.0,
+			min(
+				float(preview_max_width) / float(image.get_width()),
+				float(preview_max_height) / float(image.get_height())
+			)
+		)
+		var preview_width: int = max(1, int(floor(float(image.get_width()) * scale)))
+		var preview_height: int = max(1, int(floor(float(image.get_height()) * scale)))
+		# Full image already saved to disk — resize in-place to avoid a redundant copy
+		image.resize(preview_width, preview_height, Image.INTERPOLATE_LANCZOS)
+		var preview_path: String = screenshot_dir.path_join("screenshot_%s_preview.png" % timestamp)
+		var preview_err: Error = image.save_png(preview_path)
+		if preview_err != OK:
+			_send_response(peer, {"error": "Failed to save screenshot preview (error %d)" % preview_err})
+			return
+		response["preview_path"] = preview_path.replace("\\", "/")
+		response["preview_width"] = preview_width
+		response["preview_height"] = preview_height
+
+	_send_response(peer, response)
 
 # --- Input Simulation ---
 

--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -11,6 +11,21 @@ import { logDebug } from '../utils/logger.js';
 import { randomUUID } from 'crypto';
 
 const MAX_RUNTIME_ERROR_CONTEXT_LINES = 30;
+const SCREENSHOT_RESPONSE_MODES = ['full', 'preview', 'path_only'] as const;
+const DEFAULT_PREVIEW_MAX_WIDTH = 960;
+const DEFAULT_PREVIEW_MAX_HEIGHT = 540;
+
+type ScreenshotResponseMode = (typeof SCREENSHOT_RESPONSE_MODES)[number];
+
+interface ScreenshotBridgeResponse {
+  path?: string;
+  preview_path?: string;
+  width?: number;
+  height?: number;
+  preview_width?: number;
+  preview_height?: number;
+  error?: string;
+}
 
 // --- Tool definitions ---
 
@@ -113,7 +128,7 @@ export const runtimeToolDefinitions: ToolDefinition[] = [
   {
     name: 'take_screenshot',
     description:
-      'Capture a PNG screenshot of the running Godot viewport. Use after simulate_input or run_script to verify visual changes. Requires an active runtime session (run_project or attach_project). Returns inline base64 PNG image content plus saved-path text; includes a warnings array if runtime errors are detected. Also saved to .mcp/screenshots/ for later reference. Errors if no session is active or the bridge does not respond within timeout (default 10000ms).',
+      'Capture a PNG screenshot of the running Godot viewport. Use after simulate_input or run_script to verify visual changes. Requires an active runtime session (run_project or attach_project). responseMode defaults to full (current behavior: full inline PNG); preview saves the original and returns a bounded inline preview; path_only returns metadata only. Screenshots are saved under .mcp/screenshots. Errors if no session is active or the bridge does not respond within timeout (default 10000ms).',
     annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
@@ -121,6 +136,22 @@ export const runtimeToolDefinitions: ToolDefinition[] = [
         timeout: {
           type: 'number',
           description: 'Timeout in milliseconds to wait for the screenshot (default: 10000)',
+        },
+        responseMode: {
+          type: 'string',
+          enum: ['full', 'preview', 'path_only'],
+          description:
+            'Response payload mode. "full" returns the full inline PNG (default). "preview" returns a bounded preview inline plus paths. "path_only" returns paths only.',
+        },
+        previewMaxWidth: {
+          type: 'number',
+          description:
+            'Maximum preview width in pixels when responseMode is "preview" (default: 960)',
+        },
+        previewMaxHeight: {
+          type: 'number',
+          description:
+            'Maximum preview height in pixels when responseMode is "preview" (default: 540)',
         },
       },
       required: [],
@@ -556,6 +587,24 @@ export async function handleStopProject(runner: GodotRunner) {
   };
 }
 
+function parseScreenshotResponseMode(value: unknown): ScreenshotResponseMode | null {
+  if (value === undefined) return 'full';
+  if (typeof value !== 'string') return null;
+  return SCREENSHOT_RESPONSE_MODES.includes(value as ScreenshotResponseMode)
+    ? (value as ScreenshotResponseMode)
+    : null;
+}
+
+function parsePreviewDimension(value: unknown, fallback: number): number | null {
+  if (value === undefined) return fallback;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  return Math.max(1, Math.floor(value));
+}
+
+function normalizeScreenshotPath(path: string): string {
+  return sep === '\\' ? path.replace(/\//g, '\\') : path;
+}
+
 export async function handleTakeScreenshot(runner: GodotRunner, args: OperationParams) {
   args = normalizeParameters(args);
 
@@ -565,15 +614,35 @@ export async function handleTakeScreenshot(runner: GodotRunner, args: OperationP
   }
 
   const timeout = typeof args.timeout === 'number' ? args.timeout : 10000;
+  const responseMode = parseScreenshotResponseMode(args.responseMode);
+  if (responseMode === null) {
+    return createErrorResponse('Invalid responseMode for take_screenshot', [
+      'Use one of: "full", "preview", or "path_only"',
+    ]);
+  }
+
+  const previewMaxWidth = parsePreviewDimension(args.previewMaxWidth, DEFAULT_PREVIEW_MAX_WIDTH);
+  const previewMaxHeight = parsePreviewDimension(args.previewMaxHeight, DEFAULT_PREVIEW_MAX_HEIGHT);
+  if (previewMaxWidth === null || previewMaxHeight === null) {
+    return createErrorResponse('Invalid preview dimensions for take_screenshot', [
+      'previewMaxWidth and previewMaxHeight must be positive numbers',
+    ]);
+  }
+
+  const commandParams: Record<string, unknown> = {};
+  if (responseMode === 'preview') {
+    commandParams.preview_max_width = previewMaxWidth;
+    commandParams.preview_max_height = previewMaxHeight;
+  }
 
   try {
     const { response: responseStr, runtimeErrors } = await runner.sendCommandWithErrors(
       'screenshot',
-      {},
+      commandParams,
       timeout,
     );
 
-    let parsed: { path?: string; error?: string };
+    let parsed: ScreenshotBridgeResponse;
     try {
       parsed = JSON.parse(responseStr);
     } catch {
@@ -598,7 +667,7 @@ export async function handleTakeScreenshot(runner: GodotRunner, args: OperationP
     }
 
     // Normalize path for the local filesystem (forward slashes from GDScript)
-    const screenshotPath = sep === '\\' ? parsed.path.replace(/\//g, '\\') : parsed.path;
+    const screenshotPath = normalizeScreenshotPath(parsed.path);
 
     if (!existsSync(screenshotPath)) {
       return createErrorResponse(`Screenshot file not found at: ${screenshotPath}`, [
@@ -607,20 +676,50 @@ export async function handleTakeScreenshot(runner: GodotRunner, args: OperationP
       ]);
     }
 
-    const imageBuffer = readFileSync(screenshotPath);
-    const base64Data = imageBuffer.toString('base64');
+    const metadata: Record<string, unknown> = {
+      responseMode,
+      path: parsed.path,
+    };
+    if (typeof parsed.width === 'number' && typeof parsed.height === 'number') {
+      metadata.size = { width: parsed.width, height: parsed.height };
+    }
 
-    const content: Array<{ type: string; [key: string]: unknown }> = [
-      {
+    const content: Array<{ type: string; [key: string]: unknown }> = [];
+
+    if (responseMode === 'full') {
+      const imageBuffer = readFileSync(screenshotPath);
+      content.push({
         type: 'image',
-        data: base64Data,
+        data: imageBuffer.toString('base64'),
         mimeType: 'image/png',
-      },
-      {
-        type: 'text',
-        text: `Screenshot saved to: ${parsed.path}`,
-      },
-    ];
+      });
+    } else if (responseMode === 'preview') {
+      if (!parsed.preview_path) {
+        return createErrorResponse('Screenshot server returned no preview path', [
+          'Ensure the running project has the current McpBridge autoload',
+          'Restart the runtime after rebuilding the MCP server',
+        ]);
+      }
+      const previewPath = normalizeScreenshotPath(parsed.preview_path);
+      if (!existsSync(previewPath)) {
+        return createErrorResponse(`Screenshot preview file not found at: ${previewPath}`, [
+          'The preview may have failed to save',
+          'Try again, or use responseMode "full" to return the original screenshot',
+        ]);
+      }
+      const previewBuffer = readFileSync(previewPath);
+      content.push({
+        type: 'image',
+        data: previewBuffer.toString('base64'),
+        mimeType: 'image/png',
+      });
+      metadata.previewPath = parsed.preview_path;
+      if (typeof parsed.preview_width === 'number' && typeof parsed.preview_height === 'number') {
+        metadata.previewSize = { width: parsed.preview_width, height: parsed.preview_height };
+      }
+    }
+
+    content.push({ type: 'text', text: JSON.stringify(metadata) });
 
     if (runtimeErrors.length > 0) {
       content.push({

--- a/src/utils/bridge-manager.ts
+++ b/src/utils/bridge-manager.ts
@@ -13,8 +13,11 @@ const MCP_GITIGNORE_ENTRY = '.mcp/';
  * `.gitignore` augmentation. GodotRunner delegates to this for inject/cleanup
  * during run_project / attach_project / stop_project flows.
  *
- * Idempotent within a session via `injectedProjects`: a second `inject()` call
- * for the same path short-circuits without rewriting project.godot.
+ * The project-root bridge script is runtime-owned and refreshed on first
+ * injection for a manager session so a rebuilt server cannot talk to stale
+ * GDScript from an earlier run. Idempotent within a session via
+ * `injectedProjects`: a second `inject()` call for the same path short-circuits
+ * without rewriting project.godot.
  */
 export class BridgeManager {
   private injectedProjects: Set<string> = new Set();
@@ -31,10 +34,8 @@ export class BridgeManager {
     this.ensureGitignored(projectPath);
 
     const destScript = join(projectPath, BRIDGE_SCRIPT_FILENAME);
-    if (!existsSync(destScript)) {
-      copyFileSync(this.bridgeScriptPath, destScript);
-      logDebug(`Copied bridge autoload to ${destScript}`);
-    }
+    copyFileSync(this.bridgeScriptPath, destScript);
+    logDebug(`Refreshed bridge autoload at ${destScript}`);
 
     const projectFile = join(projectPath, 'project.godot');
     const existing = parseAutoloads(projectFile);

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -203,6 +203,9 @@ const parameterMappings: Record<string, string> = {
   new_path: 'newPath',
   file_path: 'filePath',
   script_path: 'scriptPath',
+  response_mode: 'responseMode',
+  preview_max_width: 'previewMaxWidth',
+  preview_max_height: 'previewMaxHeight',
 };
 
 // Reverse mapping from camelCase to snake_case

--- a/tests/unit/bridge-manager.test.ts
+++ b/tests/unit/bridge-manager.test.ts
@@ -83,13 +83,13 @@ describe('BridgeManager.inject', () => {
     expect(matches.length).toBe(1);
   });
 
-  it('does not re-copy the bridge script when one already exists in the project', () => {
+  it('refreshes an existing bridge script from the current source', () => {
     // First manager injects normally.
     const { projectPath, bridgeSourcePath } = setupProject();
     const firstManager = new BridgeManager(bridgeSourcePath);
     firstManager.inject(projectPath);
 
-    // Mutate the in-project bridge script to detect any re-copy.
+    // Mutate the in-project bridge script to detect the refresh.
     const destScript = join(projectPath, 'mcp_bridge.gd');
     writeFileSync(destScript, '# mutated locally\n', 'utf8');
 
@@ -97,8 +97,8 @@ describe('BridgeManager.inject', () => {
     const secondManager = new BridgeManager(bridgeSourcePath);
     secondManager.inject(projectPath);
 
-    // Because destScript already existed, the copy must be skipped.
-    expect(readFileSync(destScript, 'utf8')).toBe('# mutated locally\n');
+    // The bridge script is runtime-owned, so a fresh inject refreshes it.
+    expect(readFileSync(destScript, 'utf8')).toBe(BRIDGE_SOURCE_CONTENT);
 
     // Autoload entry remains a single, canonical line.
     const projectGodot = readFileSync(join(projectPath, 'project.godot'), 'utf8');

--- a/tests/unit/handlers/runtime-handlers.test.ts
+++ b/tests/unit/handlers/runtime-handlers.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { existsSync, readFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import {
   handleDetachProject,
@@ -700,6 +700,137 @@ describe('handleTakeScreenshot bridge response shapes', () => {
       projectPath: '/p',
       process: makeRunningProcess(),
     });
+  });
+
+  let screenshotDir: string;
+  beforeEach(() => {
+    screenshotDir = tmp.make('mcp-screenshot-');
+  });
+
+  function writeScreenshot(name: string, content = 'png-data'): string {
+    const path = join(screenshotDir, name);
+    writeFileSync(path, content, 'utf8');
+    return path;
+  }
+
+  function parseMetadata(result: { content?: Array<{ type: string; text?: string }> }) {
+    const textContent = result.content?.filter((entry) => entry.type === 'text') ?? [];
+    const metadataEntry = textContent.find((entry) => entry.text?.startsWith('{'));
+    expect(metadataEntry?.text).toBeDefined();
+    return JSON.parse(metadataEntry!.text!);
+  }
+
+  it('defaults to full mode and returns the full inline PNG', async () => {
+    const screenshotPath = writeScreenshot('screenshot.png', 'full-image');
+    fake.setBridgeResponse(JSON.stringify({ path: screenshotPath, width: 1280, height: 720 }));
+
+    const result = await handleTakeScreenshot(fake.asRunner, {});
+
+    expect(hasError(result)).toBe(false);
+    expect(fake.bridgeCalls[0]).toMatchObject({
+      command: 'screenshot',
+      params: {},
+    });
+    expect(result.content?.[0]).toMatchObject({
+      type: 'image',
+      data: Buffer.from('full-image').toString('base64'),
+      mimeType: 'image/png',
+    });
+    expect(parseMetadata(result)).toMatchObject({
+      responseMode: 'full',
+      path: screenshotPath,
+      size: { width: 1280, height: 720 },
+    });
+  });
+
+  it('returns a bounded preview image when responseMode is preview', async () => {
+    const screenshotPath = writeScreenshot('screenshot.png', 'full-image');
+    const previewPath = writeScreenshot('preview.png', 'preview-image');
+    fake.setBridgeResponse(
+      JSON.stringify({
+        path: screenshotPath,
+        preview_path: previewPath,
+        width: 1280,
+        height: 720,
+        preview_width: 960,
+        preview_height: 540,
+      }),
+    );
+
+    const result = await handleTakeScreenshot(fake.asRunner, { responseMode: 'preview' });
+
+    expect(hasError(result)).toBe(false);
+    expect(fake.bridgeCalls[0]).toMatchObject({
+      command: 'screenshot',
+      params: { preview_max_width: 960, preview_max_height: 540 },
+    });
+    expect(result.content?.[0]).toMatchObject({
+      type: 'image',
+      data: Buffer.from('preview-image').toString('base64'),
+      mimeType: 'image/png',
+    });
+    expect(parseMetadata(result)).toMatchObject({
+      responseMode: 'preview',
+      path: screenshotPath,
+      previewPath,
+      previewSize: { width: 960, height: 540 },
+    });
+  });
+
+  it('uses caller-provided preview bounds', async () => {
+    const screenshotPath = writeScreenshot('screenshot.png');
+    const previewPath = writeScreenshot('preview.png');
+    fake.setBridgeResponse(
+      JSON.stringify({
+        path: screenshotPath,
+        preview_path: previewPath,
+      }),
+    );
+
+    const result = await handleTakeScreenshot(fake.asRunner, {
+      responseMode: 'preview',
+      previewMaxWidth: 480,
+      previewMaxHeight: 270,
+    });
+
+    expect(hasError(result)).toBe(false);
+    expect(fake.bridgeCalls[0].params).toEqual({ preview_max_width: 480, preview_max_height: 270 });
+  });
+
+  it('returns metadata only when responseMode is path_only', async () => {
+    const screenshotPath = writeScreenshot('screenshot.png');
+    fake.setBridgeResponse(JSON.stringify({ path: screenshotPath }));
+
+    const result = await handleTakeScreenshot(fake.asRunner, { responseMode: 'path_only' });
+
+    expect(hasError(result)).toBe(false);
+    expect(result.content?.some((entry) => entry.type === 'image')).toBe(false);
+    expect(parseMetadata(result)).toMatchObject({
+      responseMode: 'path_only',
+      path: screenshotPath,
+    });
+  });
+
+  it('rejects invalid responseMode', async () => {
+    const result = await handleTakeScreenshot(fake.asRunner, { responseMode: 'small' });
+    expectErrorMatching(result, /responseMode/);
+  });
+
+  it('rejects invalid preview dimensions', async () => {
+    const result = await handleTakeScreenshot(fake.asRunner, {
+      responseMode: 'preview',
+      previewMaxWidth: 0,
+    });
+    expectErrorMatching(result, /preview dimensions/);
+  });
+
+  it('returns isError when preview mode receives no preview path', async () => {
+    const screenshotPath = writeScreenshot('screenshot.png');
+    fake.setBridgeResponse(JSON.stringify({ path: screenshotPath }));
+
+    const result = await handleTakeScreenshot(fake.asRunner, { responseMode: 'preview' });
+
+    expectErrorMatching(result, /no preview path/i);
   });
 
   it('returns isError when the bridge response is not JSON', async () => {


### PR DESCRIPTION
## Summary

Adds non-breaking compact response modes to `take_screenshot` so agents can avoid full inline-image context cost when they only need a preview or saved path.

  - Adds `responseMode: "full" | "preview" | "path_only"` to `take_screenshot`; default remains `full` for compatibility.
  - Adds `previewMaxWidth` / `previewMaxHeight` with 960×540 defaults for preview responses.
  - Updates the runtime bridge to save the original screenshot plus an optional bounded preview PNG.
  - Returns preview/path metadata so callers can keep audit-quality originals on disk while inspecting smaller inline images.
  - Documents the new modes in the README and adds handler coverage for full, preview, path-only, validation, and missing-file cases.

## Motivation 
To reduce token usage, use different resolution depending on what the need of screenshot is. Still testing if the agents actually follow the guidance properly though