### PR TITLE
feat: robust multi-runtime bridge support

### DIFF
--- a/src/scripts/mcp_bridge.gd
+++ b/src/scripts/mcp_bridge.gd
@@ -21,6 +21,7 @@ var tcp_server: TCPServer
 var port: int = DEFAULT_BRIDGE_PORT
 var session_token: String = ""
 var _peers: Array = []   # Array[PeerState]
+var _shutting_down: bool = false
 
 func _resolve_port() -> int:
 	var raw := OS.get_environment("MCP_BRIDGE_PORT")
@@ -591,6 +592,7 @@ func _serialize_value(value: Variant) -> Variant:
 # --- Shutdown ---
 
 func _handle_shutdown(peer: PeerState) -> void:
+	_shutting_down = true
 	_send_response(peer, {"status": "shutting_down"})
 	# Let the response flush before we tear the listener down. A new command
 	# arriving in this 2-frame window would dispatch against a peer that's
@@ -633,6 +635,8 @@ func _close_all_peers() -> void:
 	_peers.clear()
 
 func _exit_tree() -> void:
+	if not _shutting_down:
+		push_warning("McpBridge: removed from tree without shutdown — bridge connection will be lost")
 	_close_all_peers()
 	if tcp_server != null:
 		tcp_server.stop()

--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -72,6 +72,11 @@ export const runtimeToolDefinitions: ToolDefinition[] = [
           description:
             'If true, hides the Godot window off-screen and blocks all physical keyboard and mouse input, while keeping programmatic input (simulate_input, run_script) and screenshots fully active. Useful for automated agent-driven testing where the window should not be visible or interactive.',
         },
+        bridgePort: {
+          type: 'number',
+          description:
+            'TCP port for the MCP bridge. Omit to auto-select a free port. Specify to use a fixed port (e.g. when coordinating with external tools).',
+        },
       },
       required: ['projectPath'],
     },
@@ -87,6 +92,11 @@ export const runtimeToolDefinitions: ToolDefinition[] = [
         projectPath: {
           type: 'string',
           description: 'Path to the Godot project directory',
+        },
+        bridgePort: {
+          type: 'number',
+          description:
+            'TCP port where the MCP bridge is listening (default: MCP_BRIDGE_PORT env or 9900). Specify when the externally launched Godot uses a non-default port.',
         },
       },
       required: ['projectPath'],
@@ -373,7 +383,13 @@ export async function handleRunProject(runner: GodotRunner, args: OperationParam
 
   try {
     const background = args.background === true;
-    runner.runProject(v.projectPath, args.scene as string | undefined, background);
+    const bridgePort = typeof args.bridgePort === 'number' ? args.bridgePort : undefined;
+    await runner.runProject(
+      v.projectPath,
+      args.scene as string | undefined,
+      background,
+      bridgePort,
+    );
 
     const bridgeResult = await runner.waitForBridge();
 
@@ -414,8 +430,9 @@ export async function handleRunProject(runner: GodotRunner, args: OperationParam
       ]);
     }
 
+    const port = runner.activeBridgePort;
     const lines = [
-      'Godot project started and MCP bridge is ready.',
+      `Godot project started and MCP bridge is ready (port ${port}).`,
       '- Runtime tools (take_screenshot, simulate_input, get_ui_elements, run_script) are available now',
       '- Use get_debug_output to check runtime output and errors',
       '- Call stop_project when done',
@@ -428,7 +445,15 @@ export async function handleRunProject(runner: GodotRunner, args: OperationParam
       content: [{ type: 'text', text: lines.join('\n') }],
     };
   } catch (error: unknown) {
-    return createErrorResponse(`Failed to run Godot project: ${getErrorMessage(error)}`, [
+    const errorMessage = getErrorMessage(error);
+    if (errorMessage.includes('No display server available')) {
+      return createErrorResponse(`Failed to run Godot project: ${errorMessage}`, [
+        'Use attach_project with an externally launched Godot process',
+        'Set DISPLAY or WAYLAND_DISPLAY environment variables',
+        'Run from a graphical shell session',
+      ]);
+    }
+    return createErrorResponse(`Failed to run Godot project: ${errorMessage}`, [
       'Ensure Godot is installed correctly',
       'Check if the GODOT_PATH environment variable is set correctly',
     ]);
@@ -442,7 +467,8 @@ export async function handleAttachProject(runner: GodotRunner, args: OperationPa
   if ('isError' in v) return v;
 
   try {
-    await runner.attachProject(v.projectPath);
+    const attachBridgePort = typeof args.bridgePort === 'number' ? args.bridgePort : undefined;
+    await runner.attachProject(v.projectPath, attachBridgePort);
 
     const bridgeResult = await runner.waitForBridgeAttached();
 
@@ -461,12 +487,13 @@ export async function handleAttachProject(runner: GodotRunner, args: OperationPa
       );
     }
 
+    const attachedPort = runner.activeBridgePort;
     return {
       content: [
         {
           type: 'text',
           text: [
-            'Project attached and MCP bridge is ready.',
+            `Project attached and MCP bridge is ready (port ${attachedPort}).`,
             '- Runtime tools (take_screenshot, simulate_input, get_ui_elements, run_script) are available now',
             '- get_debug_output is unavailable in attached mode because MCP did not spawn the process',
             '- Use detach_project or stop_project when done to clean up the injected bridge state',

--- a/src/utils/bridge-protocol.ts
+++ b/src/utils/bridge-protocol.ts
@@ -9,6 +9,8 @@
  * Max frame size is 16 MiB; oversize frames are rejected on receive.
  */
 
+import * as net from 'net';
+
 export const DEFAULT_BRIDGE_PORT = 9900;
 export const MAX_FRAME_BYTES = 16 * 1024 * 1024;
 const FRAME_HEADER_BYTES = 4;
@@ -25,6 +27,29 @@ export function getBridgePort(): number {
     return DEFAULT_BRIDGE_PORT;
   }
   return parsed;
+}
+
+/**
+ * Find an available TCP port by binding to port 0 (OS-assigned ephemeral port),
+ * reading the assigned port, and closing the listener. The brief TOCTOU window
+ * between close and the consumer's listen is acceptable — if a collision occurs,
+ * the bridge readiness check will surface the failure.
+ */
+export function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (!addr || typeof addr === 'string') {
+        srv.close();
+        reject(new Error('Failed to determine assigned port'));
+        return;
+      }
+      const port = addr.port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
 }
 
 /**

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -6,7 +6,7 @@ import { spawn } from 'child_process';
 import * as net from 'net';
 import { randomBytes } from 'crypto';
 import { BridgeManager } from './bridge-manager.js';
-import { encodeFrame, getBridgePort, parseFrames } from './bridge-protocol.js';
+import { encodeFrame, findFreePort, getBridgePort, parseFrames } from './bridge-protocol.js';
 import { logDebug, logError } from './logger.js';
 
 /**
@@ -206,6 +206,7 @@ const parameterMappings: Record<string, string> = {
   response_mode: 'responseMode',
   preview_max_width: 'previewMaxWidth',
   preview_max_height: 'previewMaxHeight',
+  bridge_port: 'bridgePort',
 };
 
 // Reverse mapping from camelCase to snake_case
@@ -260,6 +261,16 @@ export function convertCamelToSnakeCase(params: OperationParams): OperationParam
   }
 
   return result;
+}
+
+/**
+ * Check whether a display server (X11 / Wayland) is available on the current
+ * platform.  On macOS and Windows the display subsystem is always present;
+ * on Linux we probe the standard environment variables.
+ */
+export function checkDisplayAvailable(): boolean {
+  if (process.platform !== 'linux') return true;
+  return !!(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
 }
 
 export function validatePath(path: string): boolean {
@@ -418,6 +429,7 @@ export class GodotRunner {
   public activeProcess: GodotProcess | null = null;
   public activeProjectPath: string | null = null;
   public activeSessionMode: RuntimeSessionMode | null = null;
+  public activeBridgePort: number | null = null;
 
   private socket: net.Socket | null = null;
   private rxBuffer: Buffer = Buffer.alloc(0);
@@ -675,7 +687,12 @@ export class GodotRunner {
     return spawn(this.godotPath, ['-e', '--path', projectPath], { stdio: 'pipe' });
   }
 
-  runProject(projectPath: string, scene?: string, background: boolean = false): GodotProcess {
+  async runProject(
+    projectPath: string,
+    scene?: string,
+    background: boolean = false,
+    bridgePort?: number,
+  ): Promise<GodotProcess> {
     if (!this.godotPath) {
       throw new Error('Godot path not set. Call detectGodotPath first.');
     }
@@ -696,6 +713,16 @@ export class GodotRunner {
       this.bridge.cleanup(this.activeProjectPath);
     }
 
+    if (!checkDisplayAvailable()) {
+      throw new Error(
+        'No display server available (DISPLAY and WAYLAND_DISPLAY are both unset). ' +
+          'Godot requires a display to run a project window.',
+      );
+    }
+
+    const port = bridgePort ?? (await findFreePort());
+    this.activeBridgePort = port;
+
     try {
       this.bridge.inject(projectPath);
     } catch (err) {
@@ -710,11 +737,15 @@ export class GodotRunner {
       cmdArgs.push(scene);
     }
 
-    logDebug(`Running Godot project: ${projectPath}`);
+    logDebug(`Running Godot project: ${projectPath} (bridge port ${port})`);
     const sessionToken = randomBytes(16).toString('hex');
     const spawnOptions: SpawnOptions = {
       stdio: 'pipe',
-      env: { ...process.env, MCP_SESSION_TOKEN: sessionToken },
+      env: {
+        ...process.env,
+        MCP_SESSION_TOKEN: sessionToken,
+        MCP_BRIDGE_PORT: String(port),
+      },
     };
     if (background) {
       spawnOptions.env = { ...spawnOptions.env, MCP_BACKGROUND: '1' };
@@ -773,7 +804,7 @@ export class GodotRunner {
     return this.activeProcess;
   }
 
-  async attachProject(projectPath: string): Promise<void> {
+  async attachProject(projectPath: string, bridgePort?: number): Promise<void> {
     if (this.activeSessionMode === 'spawned' && this.activeProcess) {
       await this.stopProject();
     } else if (
@@ -795,6 +826,7 @@ export class GodotRunner {
     }
 
     this.bridge.inject(projectPath);
+    this.activeBridgePort = bridgePort ?? getBridgePort();
     this.activeProjectPath = projectPath;
     this.activeSessionMode = 'attached';
     this.activeProcess = null;
@@ -821,6 +853,7 @@ export class GodotRunner {
       }
       this.activeProjectPath = null;
       this.activeSessionMode = null;
+      this.activeBridgePort = null;
       this.activeProcess = null;
       return {
         mode: 'attached',
@@ -877,6 +910,7 @@ export class GodotRunner {
       this.activeProjectPath = null;
     }
     this.activeSessionMode = null;
+    this.activeBridgePort = null;
 
     return result;
   }
@@ -951,7 +985,7 @@ export class GodotRunner {
           cb();
           return;
         }
-        const port = getBridgePort();
+        const port = this.activeBridgePort ?? getBridgePort();
         const sock = net.connect(port, '127.0.0.1');
         const onConnect = (): void => {
           sock.setNoDelay(true);
@@ -1063,9 +1097,31 @@ export class GodotRunner {
   // Only the explicit `SCRIPT ERROR:` / `USER SCRIPT ERROR:` markers belong here — the looser
   // `GDScript error` substring also matches user printerr output and produces false positives.
   private static readonly SCRIPT_ERROR_PATTERNS = ['SCRIPT ERROR:', 'USER SCRIPT ERROR:'];
+  private static readonly RETRYABLE_BRIDGE_COMMANDS = new Set(['get_ui_elements', 'screenshot']);
 
   extractRuntimeErrors(lines: string[]): string[] {
     return lines.filter((line) => GodotRunner.SCRIPT_ERROR_PATTERNS.some((p) => line.includes(p)));
+  }
+
+  private async sendCommandWithReconnect(
+    command: string,
+    params: Record<string, unknown> = {},
+    timeoutMs: number = 10000,
+  ): Promise<string> {
+    try {
+      return await this.sendCommand(command, params, timeoutMs);
+    } catch (err) {
+      if (
+        err instanceof BridgeDisconnectedError &&
+        this.activeSessionMode &&
+        GodotRunner.RETRYABLE_BRIDGE_COMMANDS.has(command)
+      ) {
+        this.closeConnection();
+        await new Promise((r) => setTimeout(r, 1000));
+        return this.sendCommand(command, params, timeoutMs);
+      }
+      throw err;
+    }
   }
 
   async sendCommandWithErrors(
@@ -1074,7 +1130,7 @@ export class GodotRunner {
     timeoutMs: number = 10000,
   ): Promise<{ response: string; runtimeErrors: string[] }> {
     const marker = this.getErrorCount();
-    const response = await this.sendCommand(command, params, timeoutMs);
+    const response = await this.sendCommandWithReconnect(command, params, timeoutMs);
     const newErrors = this.getErrorsSince(marker);
     const runtimeErrors =
       this.activeSessionMode === 'spawned' ? this.extractRuntimeErrors(newErrors) : [];

--- a/tests/integration/runtime-smoke.test.ts
+++ b/tests/integration/runtime-smoke.test.ts
@@ -73,7 +73,7 @@ describe('runtime bridge smoke', () => {
       cpSync(fixtureProjectPath, tmpProject, { recursive: true });
 
       // Start the project — waitForBridge polls until the TCP ping responds
-      runner.runProject(tmpProject);
+      await runner.runProject(tmpProject);
       const bridgeResult = await runner.waitForBridge(12000);
 
       if (!bridgeResult.ready) {
@@ -126,7 +126,7 @@ describe('runtime bridge smoke', () => {
       tmpProject = join(tmpdir(), `godot-mcp-runtime-input-${id}`);
       cpSync(fixtureProjectPath, tmpProject, { recursive: true });
 
-      runner.runProject(tmpProject);
+      await runner.runProject(tmpProject);
       const bridgeResult = await runner.waitForBridge(12000);
 
       if (!bridgeResult.ready) {

--- a/tests/unit/bridge-protocol.test.ts
+++ b/tests/unit/bridge-protocol.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_BRIDGE_PORT,
   MAX_FRAME_BYTES,
   encodeFrame,
+  findFreePort,
   getBridgePort,
   parseFrames,
 } from '../../src/utils/bridge-protocol.js';
@@ -104,6 +105,20 @@ describe('encodeFrame oversize rejection', () => {
     // approach to avoid actually allocating ~16 MiB.
     const oversize = 'a'.repeat(MAX_FRAME_BYTES + 1);
     expect(() => encodeFrame(oversize)).toThrow(/too large/);
+  });
+});
+
+describe('findFreePort', () => {
+  it('returns a valid port number', async () => {
+    const port = await findFreePort();
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThanOrEqual(65535);
+  });
+
+  it('returns different ports on consecutive calls', async () => {
+    const a = await findFreePort();
+    const b = await findFreePort();
+    expect(a).not.toBe(b);
   });
 });
 

--- a/tests/unit/godot-runner-extended.test.ts
+++ b/tests/unit/godot-runner-extended.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   cleanOutput,
   normalizeForCompare,
   validateProjectArgs,
   validateSceneArgs,
+  checkDisplayAvailable,
 } from '../../src/utils/godot-runner.js';
 import { fixtureProjectPath, fixtureScenePath } from '../helpers/fixture-paths.js';
 import { useTmpDirs } from '../helpers/tmp.js';
@@ -178,5 +179,55 @@ describe('validateSceneArgs', () => {
     expect('isError' in result).toBe(false);
     const typed = result as { projectPath: string; scenePath: string };
     expect(typed.scenePath).toBe('ghost.tscn');
+  });
+});
+
+// ─── checkDisplayAvailable ──────────────────────────────────────────────────
+
+describe('checkDisplayAvailable', () => {
+  const originalPlatform = process.platform;
+  const originalDisplay = process.env.DISPLAY;
+  const originalWayland = process.env.WAYLAND_DISPLAY;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    if (originalDisplay !== undefined) {
+      process.env.DISPLAY = originalDisplay;
+    } else {
+      delete process.env.DISPLAY;
+    }
+    if (originalWayland !== undefined) {
+      process.env.WAYLAND_DISPLAY = originalWayland;
+    } else {
+      delete process.env.WAYLAND_DISPLAY;
+    }
+  });
+
+  it('returns true on non-Linux platforms regardless of env', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    delete process.env.DISPLAY;
+    delete process.env.WAYLAND_DISPLAY;
+    expect(checkDisplayAvailable()).toBe(true);
+  });
+
+  it('returns true on Linux when DISPLAY is set', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    process.env.DISPLAY = ':0';
+    delete process.env.WAYLAND_DISPLAY;
+    expect(checkDisplayAvailable()).toBe(true);
+  });
+
+  it('returns true on Linux when WAYLAND_DISPLAY is set', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    delete process.env.DISPLAY;
+    process.env.WAYLAND_DISPLAY = 'wayland-0';
+    expect(checkDisplayAvailable()).toBe(true);
+  });
+
+  it('returns false on Linux when neither DISPLAY nor WAYLAND_DISPLAY is set', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    delete process.env.DISPLAY;
+    delete process.env.WAYLAND_DISPLAY;
+    expect(checkDisplayAvailable()).toBe(false);
   });
 });

--- a/tests/unit/godot-runner.sendCommand.test.ts
+++ b/tests/unit/godot-runner.sendCommand.test.ts
@@ -193,3 +193,94 @@ describe('GodotRunner.sendCommand (TCP)', () => {
     process.env.MCP_BRIDGE_PORT = String(bridge.port);
   });
 });
+
+describe('GodotRunner.sendCommandWithErrors reconnect (TCP)', () => {
+  let bridge: MockBridge;
+  let runner: GodotRunner;
+  let prevPort: string | undefined;
+
+  beforeEach(async () => {
+    bridge = await startMockBridge();
+    prevPort = process.env.MCP_BRIDGE_PORT;
+    process.env.MCP_BRIDGE_PORT = String(bridge.port);
+    runner = new GodotRunner({ godotPath: 'godot' });
+  });
+
+  afterEach(async () => {
+    runner.closeConnection();
+    await bridge.shutdown();
+    if (prevPort === undefined) delete process.env.MCP_BRIDGE_PORT;
+    else process.env.MCP_BRIDGE_PORT = prevPort;
+  });
+
+  it('retries once on BridgeDisconnectedError during an active session', async () => {
+    // Simulate an active session so reconnect logic kicks in.
+    (runner as unknown as { activeSessionMode: string }).activeSessionMode = 'spawned';
+
+    const pending = runner.sendCommandWithErrors('get_ui_elements', {}, 5000);
+    await bridge.nextFrame();
+    // Drop the connection mid-flight to trigger BridgeDisconnectedError.
+    bridge.closePeer();
+
+    // The reconnect delay is 1s, then it retries. The mock bridge accepts
+    // a new connection and receives the retry.
+    const retryFrame = await bridge.nextFrame();
+    expect(JSON.parse(retryFrame)).toEqual({ command: 'get_ui_elements' });
+    bridge.reply('{"nodes":[]}');
+
+    const result = await pending;
+    expect(JSON.parse(result.response)).toEqual({ nodes: [] });
+  }, 10000);
+
+  it('does not retry when no session is active', async () => {
+    // No activeSessionMode set — should fail immediately.
+    const pending = runner.sendCommand('ping');
+    await bridge.nextFrame();
+    bridge.closePeer();
+    await expect(pending).rejects.toBeInstanceOf(BridgeDisconnectedError);
+  });
+
+  it('does not retry shutdown commands', async () => {
+    (runner as unknown as { activeSessionMode: string }).activeSessionMode = 'spawned';
+
+    const pending = runner.sendCommandWithErrors('shutdown', {}, 5000);
+    await bridge.nextFrame();
+    bridge.closePeer();
+    await expect(pending).rejects.toBeInstanceOf(BridgeDisconnectedError);
+  });
+
+  it('does not retry input commands because they are not idempotent', async () => {
+    (runner as unknown as { activeSessionMode: string }).activeSessionMode = 'spawned';
+
+    const pending = runner.sendCommandWithErrors('input', { actions: [] }, 5000);
+    await bridge.nextFrame();
+    bridge.closePeer();
+    await expect(pending).rejects.toBeInstanceOf(BridgeDisconnectedError);
+  });
+
+  it('does not retry run_script commands because they may have side effects', async () => {
+    (runner as unknown as { activeSessionMode: string }).activeSessionMode = 'spawned';
+
+    const pending = runner.sendCommandWithErrors(
+      'run_script',
+      { source: 'extends RefCounted' },
+      5000,
+    );
+    await bridge.nextFrame();
+    bridge.closePeer();
+    await expect(pending).rejects.toBeInstanceOf(BridgeDisconnectedError);
+  });
+
+  it('propagates error if retry also fails', async () => {
+    (runner as unknown as { activeSessionMode: string }).activeSessionMode = 'spawned';
+
+    const pending = runner.sendCommandWithErrors('get_ui_elements', {}, 5000);
+    await bridge.nextFrame();
+    bridge.closePeer();
+
+    // Stop accepting connections so the retry also fails.
+    await bridge.stopAccepting();
+
+    await expect(pending).rejects.toBeInstanceOf(BridgeDisconnectedError);
+  }, 10000);
+});

--- a/tests/unit/handlers/runtime-handlers.test.ts
+++ b/tests/unit/handlers/runtime-handlers.test.ts
@@ -59,6 +59,7 @@ interface RuntimeFake {
   setStopResult(result: RuntimeStopResult | null): void;
   setGodotPath(path: string): void;
   setBridgeReady(ready: boolean, error?: string): void;
+  setRunProjectError(error: Error | null): void;
 }
 
 function createRuntimeFake(): RuntimeFake {
@@ -73,6 +74,7 @@ function createRuntimeFake(): RuntimeFake {
   let godotPath = '';
   let bridgeReady = true;
   let bridgeError: string | undefined;
+  let runProjectError: Error | null = null;
 
   const state: {
     activeSessionMode: RuntimeSessionMode | null;
@@ -116,14 +118,18 @@ function createRuntimeFake(): RuntimeFake {
       const proc = { on: () => proc };
       return proc as unknown as GodotProcess['process'];
     },
-    runProject(projectPath: string, _scene?: string, _background?: boolean) {
+    activeBridgePort: null as number | null,
+    runProject(projectPath: string, _scene?: string, _background?: boolean, bridgePort?: number) {
+      if (runProjectError) throw runProjectError;
       state.activeSessionMode = 'spawned';
       state.activeProjectPath = projectPath;
       state.activeProcess = makeRunningProcess();
+      fake.activeBridgePort = bridgePort ?? 19900;
     },
-    async attachProject(projectPath: string) {
+    async attachProject(projectPath: string, bridgePort?: number) {
       state.activeSessionMode = 'attached';
       state.activeProjectPath = projectPath;
+      fake.activeBridgePort = bridgePort ?? 9900;
     },
     async waitForBridge() {
       return { ready: bridgeReady, error: bridgeError };
@@ -154,6 +160,9 @@ function createRuntimeFake(): RuntimeFake {
     setBridgeReady(ready: boolean, error?: string) {
       bridgeReady = ready;
       bridgeError = error;
+    },
+    setRunProjectError(error: Error | null) {
+      runProjectError = error;
     },
   };
 }
@@ -195,6 +204,78 @@ describe('handleRunProject validation', () => {
     const fake = createRuntimeFake();
     const result = await handleRunProject(fake.asRunner, { projectPath: '/ghost' });
     expectErrorMatching(result, /not a valid godot project/i);
+  });
+
+  it('returns display-unavailable error with attach_project suggestion', async () => {
+    const fake = createRuntimeFake();
+    fake.setGodotPath('/usr/bin/godot');
+    fake.setRunProjectError(
+      new Error(
+        'No display server available (DISPLAY and WAYLAND_DISPLAY are both unset). ' +
+          'Godot requires a display to run a project window.',
+      ),
+    );
+    const result = await handleRunProject(fake.asRunner, { projectPath: fixtureProjectPath });
+    expectErrorMatching(result, /No display server available/);
+    const solutionsText = (result as { content: Array<{ text: string }> }).content[1]?.text ?? '';
+    expect(solutionsText).toMatch(/attach_project/);
+  });
+
+  it('cleans up bridge artifacts when process exits before bridge readiness', async () => {
+    const fake = createRuntimeFake();
+    fake.setGodotPath('/usr/bin/godot');
+    fake.setBridgeReady(false, 'Process exited with code 1');
+    let stopCalled = false;
+    const runner = fake.asRunner;
+    const originalStop = runner.stopProject.bind(runner);
+    (runner as unknown as Record<string, unknown>).stopProject = async () => {
+      stopCalled = true;
+      return originalStop();
+    };
+    // runProject sets activeProcess to a running process; override it to an
+    // exited process after the call so waitForBridge sees the early exit.
+    const origRun = runner.runProject.bind(runner);
+    (runner as unknown as Record<string, unknown>).runProject = (
+      pp: string,
+      s?: string,
+      b?: boolean,
+    ) => {
+      origRun(pp, s, b);
+      fake.setSession({
+        mode: 'spawned',
+        projectPath: pp,
+        process: makeRunningProcess({ hasExited: true, exitCode: 1 }),
+      });
+    };
+    const result = await handleRunProject(runner, { projectPath: fixtureProjectPath });
+    expectErrorMatching(result, /exited before.*bridge/i);
+    expect(stopCalled).toBe(true);
+  });
+});
+
+describe('handleRunProject bridge port', () => {
+  it('includes the assigned bridge port in the success response', async () => {
+    const fake = createRuntimeFake();
+    fake.setGodotPath('/usr/bin/godot');
+    fake.setBridgeReady(true);
+    const result = await handleRunProject(fake.asRunner, { projectPath: fixtureProjectPath });
+    expect(hasError(result)).toBe(false);
+    const text = (result as { content: Array<{ text: string }> }).content[0].text;
+    expect(text).toMatch(/port \d+/);
+  });
+});
+
+describe('handleAttachProject bridge port', () => {
+  it('includes the assigned bridge port in the success response', async () => {
+    const fake = createRuntimeFake();
+    fake.setBridgeReady(true);
+    const result = await handleAttachProject(fake.asRunner, {
+      projectPath: fixtureProjectPath,
+      bridgePort: 12345,
+    });
+    expect(hasError(result)).toBe(false);
+    const text = (result as { content: Array<{ text: string }> }).content[0].text;
+    expect(text).toMatch(/port 12345/);
   });
 });
 


### PR DESCRIPTION
Adds more robust runtime bridge handling for multi-runtime workflows.

  - Auto-selects a free bridge port for `run_project`, while still allowing callers to pass an explicit `bridgePort`.
  - Adds `bridgePort` support to `attach_project` so externally launched Godot instances can use non-default bridge ports.
  - Tracks and reports the active bridge port in runtime tool responses.
  - Threads `MCP_BRIDGE_PORT` into spawned Godot processes to avoid collisions on the default `9900`.
  - Adds a Linux display availability check with a clearer error path when `run_project` is used without X11/Wayland.
  - Retries safe bridge commands once after a transient disconnect, while avoiding retries for side-effectful commands like input, shutdown, and `run_script`.
  - Warns if the injected Godot bridge is removed from the tree without a clean shutdown.
