### PR TITLE
fix: surface GODOT_PATH misconfiguration instead of silent fallback (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ npm run build
 
 If Godot is on your `PATH`, you can omit `GODOT_PATH` entirely. The server will auto-detect it. Set `"DEBUG": "true"` in `env` for verbose logging.
 
+> [!IMPORTANT]
+> **Windows path gotchas.** `GODOT_PATH` must point at the Godot executable itself, not its install folder. Backslashes in JSON must be escaped or replaced with forward slashes:
+>
+> ```json
+> "GODOT_PATH": "D:\\Godot\\Godot_v4.4-stable_win64.exe"
+> // or equivalently
+> "GODOT_PATH": "D:/Godot/Godot_v4.4-stable_win64.exe"
+> ```
+>
+> Setting the variable from a wrapper `.bat` does not propagate to the MCP server — the path must live in the client's `env` block above.
+
 ### Verify
 
 Ask your AI assistant to call `get_project_info`. If it returns a Godot version string (e.g., `4.4.stable`), you're connected and working.

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,13 +112,12 @@ class GodotMcpServer {
       await this.runner.detectGodotPath();
 
       const godotPath = this.runner.getGodotPath();
-      if (!godotPath) {
-        console.error(
-          '[SERVER] Warning: Godot executable not found. Set GODOT_PATH to enable Godot tools.',
-        );
-      } else {
+      if (godotPath) {
         console.error(`[SERVER] Using Godot at: ${godotPath}`);
       }
+      // detectGodotPath() already emits a specific logError on failure (bad
+      // GODOT_PATH, no binary found, etc.). Don't duplicate with a generic
+      // warning here — the runner's message names the actual cause.
 
       const transport = new StdioServerTransport();
       await this.server.connect(transport);

--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -504,6 +504,17 @@ export async function handleRunProject(runner: GodotRunner, args: OperationParam
     }
   }
 
+  if (!runner.getGodotPath()) {
+    await runner.detectGodotPath();
+    if (!runner.getGodotPath()) {
+      return createErrorResponse('Could not find a valid Godot executable path', [
+        'Set GODOT_PATH in your MCP client config to your Godot 4.x executable',
+        'Ensure the path points at the Godot binary, not its installation folder',
+        'On Windows, escape backslashes in JSON (e.g. "D:\\\\Godot\\\\Godot.exe")',
+      ]);
+    }
+  }
+
   try {
     const background = args.background === true;
     const bridgePort = args.bridgePort;

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -638,8 +638,22 @@ export class GodotRunner {
   }
 
   async detectGodotPath(): Promise<void> {
-    if (this.godotPath && (await this.isValidGodotPath(this.godotPath))) {
-      logDebug(`Using existing Godot path: ${this.godotPath}`);
+    // Explicit paths (constructor config or GODOT_PATH) are authoritative:
+    // if they fail validation we surface the misconfiguration and leave
+    // godotPath null rather than silently substituting an auto-detected
+    // binary. The previous fallback to `C:\Program Files\Godot\Godot.exe`
+    // (and platform equivalents) masked custom-path misconfiguration as
+    // generic "not found" errors against a path the user never chose.
+    if (this.godotPath) {
+      if (await this.isValidGodotPath(this.godotPath)) {
+        logDebug(`Using existing Godot path: ${this.godotPath}`);
+        return;
+      }
+      logError(
+        `Configured Godot path "${this.godotPath}" is not a working Godot executable. ` +
+          `Pass a valid Godot 4.x binary via the godotPath config option.`,
+      );
+      this.godotPath = null;
       return;
     }
 
@@ -651,6 +665,11 @@ export class GodotRunner {
         logDebug(`Using Godot path from environment: ${this.godotPath}`);
         return;
       }
+      logError(
+        `GODOT_PATH is set to "${normalizedPath}" but no working Godot executable was found there. ` +
+          `Update GODOT_PATH to your Godot 4.x binary or unset it to auto-detect.`,
+      );
+      return;
     }
 
     const osPlatform = process.platform;
@@ -690,17 +709,10 @@ export class GodotRunner {
       return;
     }
 
-    logDebug(`Warning: Could not find Godot in common locations for ${osPlatform}`);
-    logError(`Could not find Godot in common locations for ${osPlatform}`);
-
-    if (osPlatform === 'win32') {
-      this.godotPath = normalize('C:\\Program Files\\Godot\\Godot.exe');
-    } else if (osPlatform === 'darwin') {
-      this.godotPath = normalize('/Applications/Godot.app/Contents/MacOS/Godot');
-    } else {
-      this.godotPath = normalize('/usr/bin/godot');
-    }
-    logDebug(`Using default path: ${this.godotPath}, but this may not work.`);
+    logError(
+      `Could not find Godot in common locations for ${osPlatform}. ` +
+        `Set GODOT_PATH to your Godot 4.x executable.`,
+    );
   }
 
   getGodotPath(): string | null {
@@ -797,7 +809,9 @@ export class GodotRunner {
 
   launchEditor(projectPath: string): ChildProcess {
     if (!this.godotPath) {
-      throw new Error('Godot path not set. Call detectGodotPath first.');
+      throw new Error(
+        'No Godot executable resolved. Set GODOT_PATH to a Godot 4.x binary, or pass godotPath via config.',
+      );
     }
     return spawn(this.godotPath, ['-e', '--path', projectPath], { stdio: 'pipe' });
   }
@@ -809,7 +823,9 @@ export class GodotRunner {
     bridgePort?: number,
   ): Promise<GodotProcess> {
     if (!this.godotPath) {
-      throw new Error('Godot path not set. Call detectGodotPath first.');
+      throw new Error(
+        'No Godot executable resolved. Set GODOT_PATH to a Godot 4.x binary, or pass godotPath via config.',
+      );
     }
 
     if (this.activeSessionMode === 'spawned' && this.activeProcess) {

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -638,12 +638,9 @@ export class GodotRunner {
   }
 
   async detectGodotPath(): Promise<void> {
-    // Explicit paths (constructor config or GODOT_PATH) are authoritative:
-    // if they fail validation we surface the misconfiguration and leave
-    // godotPath null rather than silently substituting an auto-detected
-    // binary. The previous fallback to `C:\Program Files\Godot\Godot.exe`
-    // (and platform equivalents) masked custom-path misconfiguration as
-    // generic "not found" errors against a path the user never chose.
+    // Explicit paths (constructor config or GODOT_PATH) are authoritative — leave
+    // godotPath null on failure rather than fabricating a platform default, so
+    // callers can produce actionable errors.
     if (this.godotPath) {
       if (await this.isValidGodotPath(this.godotPath)) {
         logDebug(`Using existing Godot path: ${this.godotPath}`);

--- a/tests/unit/godot-runner-extended.test.ts
+++ b/tests/unit/godot-runner-extended.test.ts
@@ -5,6 +5,7 @@ import {
   validateProjectArgs,
   validateSceneArgs,
   checkDisplayAvailable,
+  GodotRunner,
 } from '../../src/utils/godot-runner.js';
 import { fixtureProjectPath, fixtureScenePath } from '../helpers/fixture-paths.js';
 import { useTmpDirs } from '../helpers/tmp.js';
@@ -244,5 +245,62 @@ describe('checkDisplayAvailable', () => {
     delete process.env.DISPLAY;
     delete process.env.WAYLAND_DISPLAY;
     expect(checkDisplayAvailable()).toBe(false);
+  });
+});
+
+// ─── detectGodotPath ────────────────────────────────────────────────────────
+
+describe('detectGodotPath', () => {
+  const originalGodotPath = process.env.GODOT_PATH;
+
+  afterEach(() => {
+    if (originalGodotPath !== undefined) {
+      process.env.GODOT_PATH = originalGodotPath;
+    } else {
+      delete process.env.GODOT_PATH;
+    }
+  });
+
+  // Regression: issue #15 — a misconfigured GODOT_PATH used to be silently
+  // swallowed and the runner fell back to platform defaults (e.g. on Windows
+  // `C:\Program Files\Godot\Godot.exe`). Users who installed Godot elsewhere
+  // got "file not found" errors against a path they never chose. An explicit
+  // GODOT_PATH must now be authoritative — if it doesn't resolve, leave
+  // godotPath null so the caller can produce an actionable error instead.
+  it('leaves godotPath null when GODOT_PATH points to a non-existent file', async () => {
+    process.env.GODOT_PATH = '/nonexistent/godot-mcp-test-bogus-binary';
+    const runner = new GodotRunner();
+    await runner.detectGodotPath();
+    expect(runner.getGodotPath()).toBeNull();
+  });
+
+  it('leaves godotPath null when GODOT_PATH is set but invalid, even if auto-detect would succeed', async () => {
+    // Even on a developer machine where `godot` is on PATH, an explicit
+    // (broken) GODOT_PATH must not silently fall through to the PATH binary —
+    // doing so masks the user's intent.
+    process.env.GODOT_PATH = '/nonexistent/godot-mcp-test-bogus-binary';
+    const runner = new GodotRunner();
+    await runner.detectGodotPath();
+    expect(runner.getGodotPath()).toBeNull();
+  });
+
+  it('does not invent a hardcoded platform-default path when auto-detect finds nothing', async () => {
+    // Pre-fix behavior set godotPath to `C:\Program Files\Godot\Godot.exe`
+    // (Windows) / `/usr/bin/godot` (Linux) / `/Applications/Godot.app/...`
+    // (macOS) when nothing was found, then later spawn calls failed against
+    // that fabricated path. The runner must leave godotPath null instead.
+    delete process.env.GODOT_PATH;
+    const runner = new GodotRunner({ godotPath: '/nonexistent/godot-mcp-test-bogus-binary' });
+    // Constructor sync-validation rejects the bogus path, so godotPath starts null.
+    expect(runner.getGodotPath()).toBeNull();
+    await runner.detectGodotPath();
+    // After detection: still null unless this machine actually has Godot
+    // somewhere in the auto-detect search list. In CI (no Godot), null.
+    // Locally with Godot on PATH, this is a real working path — not the
+    // fabricated platform default.
+    const resolved = runner.getGodotPath();
+    if (resolved !== null) {
+      expect(resolved).not.toMatch(/Program Files\\Godot\\Godot\.exe$/);
+    }
   });
 });

--- a/tests/unit/godot-runner-extended.test.ts
+++ b/tests/unit/godot-runner-extended.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   cleanOutput,
   normalizeForCompare,
@@ -277,11 +277,24 @@ describe('detectGodotPath', () => {
   it('leaves godotPath null when GODOT_PATH is set but invalid, even if auto-detect would succeed', async () => {
     // Even on a developer machine where `godot` is on PATH, an explicit
     // (broken) GODOT_PATH must not silently fall through to the PATH binary —
-    // doing so masks the user's intent.
+    // doing so masks the user's intent. We stub isValidGodotPath so auto-detect
+    // would unambiguously succeed for `godot`; the assertion proves the
+    // explicit-invalid branch short-circuits before auto-detect runs.
     process.env.GODOT_PATH = '/nonexistent/godot-mcp-test-bogus-binary';
     const runner = new GodotRunner();
+    const spy = vi
+      .spyOn(
+        runner as unknown as { isValidGodotPath: (p: string) => Promise<boolean> },
+        'isValidGodotPath',
+      )
+      .mockImplementation(async (p: string) => p === 'godot');
     await runner.detectGodotPath();
     expect(runner.getGodotPath()).toBeNull();
+    // Sanity: the auto-detect candidates were never probed — the explicit
+    // GODOT_PATH branch short-circuited before reaching auto-detect.
+    const probed = spy.mock.calls.map((c) => c[0]);
+    expect(probed).not.toContain('godot');
+    spy.mockRestore();
   });
 
   it('does not invent a hardcoded platform-default path when auto-detect finds nothing', async () => {

--- a/tests/unit/handlers/runtime-handlers.test.ts
+++ b/tests/unit/handlers/runtime-handlers.test.ts
@@ -230,6 +230,20 @@ describe('handleRunProject validation', () => {
     expectErrorMatching(result, /not a valid godot project/i);
   });
 
+  // Regression: issue #15 — without an explicit Godot-path precheck, an
+  // unresolved godotPath used to bubble up as a generic "Failed to run
+  // Godot project" error pointing at a hardcoded `C:\Program Files\...`
+  // fallback path the user never configured. The handler must now surface
+  // a clear "set GODOT_PATH" message before attempting to spawn.
+  it('returns a "set GODOT_PATH" error when no Godot executable can be resolved', async () => {
+    const fake = createRuntimeFake();
+    // godotPath stays empty (default), so the precheck must fire.
+    const result = await handleRunProject(fake.asRunner, { projectPath: fixtureProjectPath });
+    expectErrorMatching(result, /Could not find a valid Godot executable path/);
+    const solutionsText = (result as { content: Array<{ text: string }> }).content[1]?.text ?? '';
+    expect(solutionsText).toMatch(/GODOT_PATH/);
+  });
+
   it('returns display-unavailable error with attach_project suggestion', async () => {
     const fake = createRuntimeFake();
     fake.setGodotPath('/usr/bin/godot');
@@ -306,6 +320,7 @@ describe('handleAttachProject bridge port', () => {
 describe('handleRunProject bridge failure paths', () => {
   it('returns "exited before MCP bridge could initialize" error when process exits during wait', async () => {
     const fake = createRuntimeFake();
+    fake.setGodotPath('/usr/bin/godot');
     fake.setBridgeReady(false, 'process gone');
     // Replace the default runProject so the post-state has hasExited=true.
     // The handler must take the "process exited" branch (not the timeout
@@ -327,6 +342,7 @@ describe('handleRunProject bridge failure paths', () => {
 
   it('returns "bridge did not respond" error and tears down when bridge times out', async () => {
     const fake = createRuntimeFake();
+    fake.setGodotPath('/usr/bin/godot');
     fake.setBridgeReady(false, 'timeout after 5s');
     // The default fake.runProject sets process with hasExited=false, so the
     // handler takes the timeout branch (not the process-exited branch).


### PR DESCRIPTION
## Summary

Fixes #15: a misconfigured `GODOT_PATH` was silently swallowed and replaced with a hardcoded platform default (e.g. `C:\Program Files\Godot\Godot.exe` on Windows). Subsequent `run_project` calls then failed with generic "not found" errors against a path the user never configured, and LLM clients responded by looping retries.

- `detectGodotPath` no longer fabricates a platform-default fallback. An explicit `godotPath` (constructor config or `GODOT_PATH` env) is authoritative — if it fails validation, `godotPath` stays `null` and a clear `logError` names the bad value. The "explicit-wins" branch short-circuits before auto-detect runs, so a typo'd `GODOT_PATH` won't silently fall through to a `godot` binary on `PATH`.
- `handleRunProject` prechecks for a resolved Godot path (mirroring `handleLaunchEditor`) and returns a structured "Could not find a valid Godot executable path" error with Windows-specific solutions (JSON escaping, point at the .exe, set `GODOT_PATH` in the client env block), instead of the generic "Failed to run Godot project" from the catch block.
- `index.ts` startup drops the redundant generic warning — the runner now emits a specific `logError` naming the actual cause (bad `GODOT_PATH`, no binary found, etc.).
- README gains a Windows `GODOT_PATH` gotchas callout covering JSON backslash escaping, executable-vs-folder, and the `.bat`-wrapper-doesn't-propagate trap.
- New regression tests: explicit-but-invalid `GODOT_PATH` leaves `godotPath` null even when auto-detect would succeed (stubbed `isValidGodotPath` proves the short-circuit); auto-detect failure no longer invents a platform default; handler returns the `GODOT_PATH` error before attempting to spawn.

## Test plan

- [x] `npm run verify` passes locally with `GODOT_PATH=D:/Godot/latest/godot.exe` (808 tests pass, 1 platform-skipped)
- [x] `npm run verify` passes without `GODOT_PATH` (Godot integration tests skip cleanly)
- [x] CI green on Node 20/22/24