### PR TITLE
fix: emit structuredContent for tools with outputSchema

### DIFF
--- a/docs/tool-authoring.md
+++ b/docs/tool-authoring.md
@@ -56,6 +56,10 @@ When both are present, they must be consistent — same field names, same semant
 
 When `outputSchema` is impractical (oneOf variants, bare-array, recursive trees, opaque values), the `Returns:` sentence is the only return-shape signal and carries the full load.
 
+### `structuredContent` is mandatory when `outputSchema` is declared
+
+MCP spec revision 2025-06-18: any tool that declares `outputSchema` must return a matching `structuredContent` field on success. Strict clients (LM Studio, Open Code, AnythingLLM) reject responses that omit it. Route success paths through `createStructuredResponse(payload, extraContent?)` from `src/utils/godot-runner.ts` — it emits the payload both as a JSON text content block (for lenient clients) and as `structuredContent` (for strict clients). For headless GDScript ops whose script emits JSON, pass `{ parseStdoutAsJson: true }` as the options arg to `executeSceneOp` and the helper does the wrapping. The payload shape must match `outputSchema`; if you change one, change the other.
+
 ### Harness visibility — what the agent actually sees
 
 Harnesses (Claude Code, MCP clients, etc.) inline `inputSchema` — including every per-property `description` — into the tool list the LLM reads. They typically **do not** inline `outputSchema`. This produces a useful asymmetry: per-property descriptions inside `inputSchema` are a high-value agent-facing surface, scoped to the field the agent is about to fill in.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-mcp-runtime",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A lightweight, zero-footprint TypeScript MCP server that lets AI assistants interact with the Godot 4.x game engine: not just editing files, but playing the game.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ class GodotMcpServer {
     this.server = new Server(
       {
         name: 'godot-mcp',
-        version: '3.1.1',
+        version: '3.1.2',
       },
       {
         capabilities: {

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -300,7 +300,7 @@ func create_scene(params):
 		return
 
 	if save_scene_to_path(scene_root, full_scene_path):
-		print("Scene created successfully at: " + params.scene_path)
+		print(JSON.stringify({"success": true, "scenePath": params.scene_path}))
 	else:
 		log_error("Failed to create scene: " + params.scene_path)
 		quit(1)
@@ -659,7 +659,11 @@ func attach_script(params):
 	node.set_script(script)
 
 	if save_scene_to_path(scene_root, params.scene_path):
-		print("Script '" + params.script_path + "' attached successfully to node '" + params.node_path + "'")
+		print(JSON.stringify({
+			"success": true,
+			"nodePath": params.node_path,
+			"scriptPath": params.script_path
+		}))
 	else:
 		log_error("Failed to save scene after attaching script")
 		quit(1)
@@ -709,8 +713,27 @@ func duplicate_node(params):
 		current.owner = scene_root
 		queue.append_array(current.get_children())
 
+	# Compute the new node's scene-relative path: parent path + "/" + duplicate.name.
+	# The scene tree isn't attached in headless mode so get_path() is unreliable;
+	# derive parent path from the input node_path (or target_parent_path).
+	var parent_relative_path: String
+	if params.has("target_parent_path"):
+		parent_relative_path = params.target_parent_path
+	else:
+		var last_slash = params.node_path.rfind("/")
+		parent_relative_path = params.node_path.substr(0, last_slash) if last_slash > 0 else ""
+	var new_path: String
+	if parent_relative_path == "":
+		new_path = String(duplicate.name)
+	else:
+		new_path = parent_relative_path + "/" + String(duplicate.name)
+
 	if save_scene_to_path(scene_root, params.scene_path):
-		print("Node duplicated successfully as '" + duplicate.name + "'")
+		print(JSON.stringify({
+			"success": true,
+			"originalPath": params.node_path,
+			"newPath": new_path
+		}))
 	else:
 		log_error("Failed to save scene after duplicating node")
 		quit(1)

--- a/src/tools/node-tools.ts
+++ b/src/tools/node-tools.ts
@@ -328,9 +328,16 @@ export async function handleDeleteNodes(runner: GodotRunner, args: OperationPara
   }
 
   const params = { scenePath: args.scenePath, nodePaths: args.nodePaths };
-  return executeSceneOp(runner, 'delete_nodes', params, v.projectPath, 'Failed to delete nodes', [
-    'Check if the node paths are correct',
-  ]);
+  return executeSceneOp(
+    runner,
+    'delete_nodes',
+    params,
+    v.projectPath,
+    'Failed to delete nodes',
+    ['Check if the node paths are correct'],
+    undefined,
+    { parseStdoutAsJson: true },
+  );
 }
 
 export async function handleSetNodeProperties(runner: GodotRunner, args: OperationParams) {
@@ -356,6 +363,8 @@ export async function handleSetNodeProperties(runner: GodotRunner, args: Operati
     v.projectPath,
     'Failed to set node properties',
     ['Check node paths and property names'],
+    undefined,
+    { parseStdoutAsJson: true },
   );
 }
 
@@ -408,9 +417,16 @@ export async function handleAttachScript(runner: GodotRunner, args: OperationPar
     nodePath: args.nodePath,
     scriptPath: args.scriptPath,
   };
-  return executeSceneOp(runner, 'attach_script', params, v.projectPath, 'Failed to attach script', [
-    'Ensure the script is valid for this node type',
-  ]);
+  return executeSceneOp(
+    runner,
+    'attach_script',
+    params,
+    v.projectPath,
+    'Failed to attach script',
+    ['Ensure the script is valid for this node type'],
+    undefined,
+    { parseStdoutAsJson: true },
+  );
 }
 
 export async function handleGetSceneTree(runner: GodotRunner, args: OperationParams) {
@@ -463,6 +479,8 @@ export async function handleDuplicateNode(runner: GodotRunner, args: OperationPa
     v.projectPath,
     'Failed to duplicate node',
     ['Check if the node path and target parent path are correct'],
+    undefined,
+    { parseStdoutAsJson: true },
   );
 }
 
@@ -485,6 +503,8 @@ export async function handleGetNodeSignals(runner: GodotRunner, args: OperationP
     v.projectPath,
     'Failed to get node signals',
     ['Check if the node path is correct'],
+    undefined,
+    { parseStdoutAsJson: true },
   );
 }
 

--- a/src/tools/project-tools.ts
+++ b/src/tools/project-tools.ts
@@ -7,6 +7,7 @@ import {
   validateSubPath,
   validateProjectArgs,
   createErrorResponse,
+  createStructuredResponse,
   getErrorMessage,
   projectGodotPath,
 } from '../utils/godot-runner.js';
@@ -546,7 +547,7 @@ export async function handleSearchProject(args: OperationParams) {
       caseSensitive,
       maxResults,
     );
-    return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+    return createStructuredResponse(result as unknown as Record<string, unknown>);
   } catch (error: unknown) {
     return createErrorResponse(`Failed to search project: ${getErrorMessage(error)}`, [
       'Check if the project directory is accessible',
@@ -597,9 +598,10 @@ export async function handleGetSceneDependencies(args: OperationParams) {
         dependencies.push(dep);
       }
     }
-    return {
-      content: [{ type: 'text', text: JSON.stringify({ scene: args.scenePath, dependencies }) }],
-    };
+    return createStructuredResponse({
+      scene: args.scenePath as string,
+      dependencies,
+    });
   } catch (error: unknown) {
     return createErrorResponse(`Failed to get scene dependencies: ${getErrorMessage(error)}`, [
       'Check if the scene file is accessible',

--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -6,6 +6,7 @@ import {
   validateProjectArgs,
   validateSubPath,
   createErrorResponse,
+  createStructuredResponse,
   getErrorMessage,
   isUnderDir,
   BRIDGE_WAIT_SPAWNED_TIMEOUT_MS,
@@ -410,7 +411,6 @@ export const runtimeToolDefinitions: ToolDefinition[] = [
       properties: {
         success: { type: 'boolean' },
         result: {},
-        warning: { type: 'string' },
         warnings: { type: 'array', items: { type: 'string' } },
         tip: { type: 'string' },
       },
@@ -704,17 +704,10 @@ export async function handleDetachProject(runner: GodotRunner) {
 
   const result = (await runner.stopProject())!;
 
-  return {
-    content: [
-      {
-        type: 'text',
-        text: JSON.stringify({
-          message: 'Detached attached project and cleaned MCP bridge state',
-          externalProcessPreserved: result.externalProcessPreserved === true,
-        }),
-      },
-    ],
-  };
+  return createStructuredResponse({
+    message: 'Detached attached project and cleaned MCP bridge state',
+    externalProcessPreserved: result.externalProcessPreserved === true,
+  });
 }
 
 export function handleGetDebugOutput(runner: GodotRunner, args: OperationParams = {}) {
@@ -728,20 +721,13 @@ export function handleGetDebugOutput(runner: GodotRunner, args: OperationParams 
   }
 
   if (runner.activeSessionMode === 'attached') {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify({
-            output: [],
-            errors: [],
-            running: null,
-            attached: true,
-            tip: 'Attached mode does not capture stdout/stderr because Godot was launched outside MCP.',
-          }),
-        },
-      ],
-    };
+    return createStructuredResponse({
+      output: [],
+      errors: [],
+      running: null,
+      attached: true,
+      tip: 'Attached mode does not capture stdout/stderr because Godot was launched outside MCP.',
+    });
   }
 
   const proc = runner.activeProcess;
@@ -771,14 +757,7 @@ export function handleGetDebugOutput(runner: GodotRunner, args: OperationParams 
       'Process has exited. Call stop_project to clean up the process slot before starting a new one.';
   }
 
-  return {
-    content: [
-      {
-        type: 'text',
-        text: JSON.stringify(response),
-      },
-    ],
-  };
+  return createStructuredResponse(response);
 }
 
 export async function handleStopProject(runner: GodotRunner) {
@@ -791,23 +770,16 @@ export async function handleStopProject(runner: GodotRunner) {
     ]);
   }
 
-  return {
-    content: [
-      {
-        type: 'text',
-        text: JSON.stringify({
-          message:
-            result.mode === 'attached'
-              ? 'Attached project detached and MCP bridge state cleaned up'
-              : 'Godot project stopped',
-          mode: result.mode,
-          externalProcessPreserved: result.externalProcessPreserved === true,
-          finalOutput: result.output.slice(-200),
-          finalErrors: result.errors.slice(-200),
-        }),
-      },
-    ],
-  };
+  return createStructuredResponse({
+    message:
+      result.mode === 'attached'
+        ? 'Attached project detached and MCP bridge state cleaned up'
+        : 'Godot project stopped',
+    mode: result.mode,
+    externalProcessPreserved: result.externalProcessPreserved === true,
+    finalOutput: result.output.slice(-200),
+    finalErrors: result.errors.slice(-200),
+  });
 }
 
 function parseScreenshotResponseMode(value: unknown): ScreenshotResponseMode | null {
@@ -957,9 +929,7 @@ export async function handleTakeScreenshot(runner: GodotRunner, args: OperationP
 
     attachRuntimeWarnings(metadata, runtimeErrors);
 
-    content.push({ type: 'text', text: JSON.stringify(metadata) });
-
-    return { content };
+    return createStructuredResponse(metadata, content);
   } catch (error: unknown) {
     return createErrorResponse(`Failed to take screenshot: ${getErrorMessage(error)}`, [
       'Check get_debug_output for crash backtraces or runtime errors',
@@ -1027,14 +997,7 @@ export async function handleSimulateInput(runner: GodotRunner, args: OperationPa
     };
     attachRuntimeWarnings(payload, runtimeErrors);
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(payload),
-        },
-      ],
-    };
+    return createStructuredResponse(payload);
   } catch (error: unknown) {
     return createErrorResponse(`Failed to simulate input: ${getErrorMessage(error)}`, [
       'Check get_debug_output for crash backtraces or runtime errors (a signal handler firing on input may have crashed the game)',
@@ -1080,14 +1043,7 @@ export async function handleGetUiElements(runner: GodotRunner, args: OperationPa
     };
     attachRuntimeWarnings(payload, runtimeErrors);
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(payload),
-        },
-      ],
-    };
+    return createStructuredResponse(payload);
   } catch (error: unknown) {
     return createErrorResponse(`Failed to get UI elements: ${getErrorMessage(error)}`, [
       'Check get_debug_output for crash backtraces or runtime errors',
@@ -1169,20 +1125,14 @@ export async function handleRunScript(runner: GodotRunner, args: OperationParams
         ]);
       }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              result: null,
-              warning:
-                'Script returned null. If unexpected, check get_debug_output for runtime errors — GDScript does not propagate exceptions.',
-              tip: 'Call take_screenshot to verify any visual changes, or get_debug_output to review print() output from your script.',
-            }),
-          },
+      return createStructuredResponse({
+        success: true,
+        result: null,
+        warnings: [
+          'Script returned null. If unexpected, check get_debug_output for runtime errors — GDScript does not propagate exceptions.',
         ],
-      };
+        tip: 'Call take_screenshot to verify any visual changes, or get_debug_output to review print() output from your script.',
+      });
     }
 
     const payload: Record<string, unknown> = {
@@ -1192,14 +1142,7 @@ export async function handleRunScript(runner: GodotRunner, args: OperationParams
     };
     attachRuntimeWarnings(payload, runtimeErrors);
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(payload),
-        },
-      ],
-    };
+    return createStructuredResponse(payload);
   } catch (error: unknown) {
     return createErrorResponse(`Failed to execute script: ${getErrorMessage(error)}`, [
       'Check get_debug_output for crash backtraces or runtime errors raised inside the script',

--- a/src/tools/scene-tools.ts
+++ b/src/tools/scene-tools.ts
@@ -241,9 +241,16 @@ export async function handleCreateScene(runner: GodotRunner, args: OperationPara
     scenePath: args.scenePath,
     rootNodeType: args.rootNodeType || 'Node2D',
   };
-  return executeSceneOp(runner, 'create_scene', params, v.projectPath, 'Failed to create scene', [
-    'Check if the root node type is valid',
-  ]);
+  return executeSceneOp(
+    runner,
+    'create_scene',
+    params,
+    v.projectPath,
+    'Failed to create scene',
+    ['Check if the root node type is valid'],
+    undefined,
+    { parseStdoutAsJson: true },
+  );
 }
 
 export async function handleAddNode(runner: GodotRunner, args: OperationParams) {
@@ -384,5 +391,7 @@ export async function handleBatchSceneOperations(runner: GodotRunner, args: Oper
     v.projectPath,
     'Batch scene operations failed',
     ['Check that all scene paths exist', 'Ensure node types are valid'],
+    undefined,
+    { parseStdoutAsJson: true },
   );
 }

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -186,6 +186,7 @@ export interface ToolDefinition {
 export interface ToolResponse {
   content: Array<{ type: string; text?: string; [k: string]: unknown }>;
   isError?: boolean;
+  structuredContent?: Record<string, unknown>;
   [k: string]: unknown;
 }
 
@@ -418,6 +419,25 @@ export function createErrorResponse(
   }
 
   return response;
+}
+
+/**
+ * Wrap a structured payload as a ToolResponse that satisfies the MCP
+ * outputSchema contract. The same payload is emitted both as a JSON text
+ * content block (for lenient clients) and as `structuredContent` (required
+ * by strict clients per MCP spec revision 2025-06-18).
+ *
+ * `extraContent` is prepended for handlers that also return non-text blocks
+ * (e.g. `take_screenshot`'s inline image).
+ */
+export function createStructuredResponse<T extends Record<string, unknown>>(
+  payload: T,
+  extraContent: Array<{ type: string; [k: string]: unknown }> = [],
+): ToolResponse {
+  return {
+    content: [...extraContent, { type: 'text', text: JSON.stringify(payload) }],
+    structuredContent: payload,
+  };
 }
 
 // --- Shared validation helpers ---

--- a/src/utils/handler-helpers.ts
+++ b/src/utils/handler-helpers.ts
@@ -1,5 +1,10 @@
 import type { GodotRunner, OperationParams, ToolResponse } from './godot-runner.js';
-import { createErrorResponse, extractGdError, getErrorMessage } from './godot-runner.js';
+import {
+  createErrorResponse,
+  createStructuredResponse,
+  extractGdError,
+  getErrorMessage,
+} from './godot-runner.js';
 
 export const MAX_RUNTIME_ERROR_CONTEXT_LINES = 30;
 
@@ -22,6 +27,7 @@ export async function executeSceneOp(
   failurePrefix: string,
   emptyStdoutSolutions: string[],
   exceptionSolutions: string[] = ['Ensure Godot is installed correctly'],
+  options: { parseStdoutAsJson?: boolean } = {},
 ): Promise<ToolResponse> {
   try {
     const { stdout, stderr } = await runner.executeOperation(operation, params, projectPath);
@@ -30,6 +36,20 @@ export async function executeSceneOp(
         `${failurePrefix}: ${extractGdError(stderr)}`,
         emptyStdoutSolutions,
       );
+    }
+    if (options.parseStdoutAsJson) {
+      try {
+        const payload = JSON.parse(stdout.trim()) as Record<string, unknown>;
+        return createStructuredResponse(payload);
+      } catch (parseErr) {
+        return createErrorResponse(
+          `${failurePrefix}: GDScript returned invalid JSON (${getErrorMessage(parseErr)})`,
+          [
+            'This indicates a bug in godot_operations.gd — the operation should emit a JSON payload matching its outputSchema',
+            'Check get_debug_output for the raw stdout and stderr',
+          ],
+        );
+      }
     }
     return { content: [{ type: 'text', text: stdout }] };
   } catch (error: unknown) {

--- a/tests/integration/mcp-output-schema.test.ts
+++ b/tests/integration/mcp-output-schema.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Integration test for issue #18.
+ *
+ * The MCP spec (revision 2025-06-18) requires tools that declare
+ * `outputSchema` to return a matching `structuredContent` field on success.
+ * The @modelcontextprotocol/sdk Client validator at
+ * `node_modules/@modelcontextprotocol/sdk/dist/esm/client/index.js:500`
+ * enforces this — strict clients (LM Studio, Open Code, AnythingLLM) reject
+ * responses that omit it.
+ *
+ * This test wires the real lower-level `Server` (matching production in
+ * `src/index.ts`) to a real `Client` over an in-memory transport and calls
+ * filesystem-only tools through the actual dispatch table to verify
+ * `structuredContent` is emitted with the schema-declared shape.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+import { dispatchToolCall } from '../../src/dispatch.js';
+import { runtimeToolDefinitions } from '../../src/tools/runtime-tools.js';
+import { autoloadToolDefinitions } from '../../src/tools/autoload-tools.js';
+import { projectToolDefinitions } from '../../src/tools/project-tools.js';
+import { sceneToolDefinitions } from '../../src/tools/scene-tools.js';
+import { nodeToolDefinitions } from '../../src/tools/node-tools.js';
+import { validateToolDefinitions } from '../../src/tools/validate-tools.js';
+
+import { GodotRunner } from '../../src/utils/godot-runner.js';
+import { fixtureProjectPath } from '../helpers/fixture-paths.js';
+
+const allToolDefinitions = [
+  ...runtimeToolDefinitions,
+  ...autoloadToolDefinitions,
+  ...projectToolDefinitions,
+  ...sceneToolDefinitions,
+  ...nodeToolDefinitions,
+  ...validateToolDefinitions,
+];
+
+async function makeLinkedPair() {
+  const runner = new GodotRunner();
+  const server = new Server(
+    { name: 'godot-mcp-test', version: '0.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: allToolDefinitions,
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    return await dispatchToolCall(runner, request.params.name, request.params.arguments || {});
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  // Populate the client's per-tool outputSchema validator cache. The strict
+  // check in client/index.js:500 only runs for tools whose schemas the client
+  // has seen, so listTools() must be called before callTool() to reproduce.
+  await client.listTools();
+
+  return { client, server };
+}
+
+describe('MCP outputSchema contract (issue #18)', () => {
+  it('search_project: returns structuredContent matching outputSchema', async () => {
+    const { client, server } = await makeLinkedPair();
+
+    try {
+      const result = (await client.callTool({
+        name: 'search_project',
+        arguments: {
+          projectPath: fixtureProjectPath,
+          // A pattern guaranteed to match content in fixture's main.tscn
+          // (default fileTypes excludes the .godot extension).
+          pattern: 'Sprite2D',
+        },
+      })) as { structuredContent?: { matches?: unknown[]; truncated?: boolean } };
+
+      expect(result.structuredContent).toBeDefined();
+      expect(Array.isArray(result.structuredContent?.matches)).toBe(true);
+      expect(typeof result.structuredContent?.truncated).toBe('boolean');
+      expect(result.structuredContent!.matches!.length).toBeGreaterThan(0);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('get_scene_dependencies: returns structuredContent matching outputSchema', async () => {
+    const { client, server } = await makeLinkedPair();
+
+    try {
+      const result = (await client.callTool({
+        name: 'get_scene_dependencies',
+        arguments: {
+          projectPath: fixtureProjectPath,
+          scenePath: 'main.tscn',
+        },
+      })) as { structuredContent?: { scene?: string; dependencies?: unknown[] } };
+
+      expect(result.structuredContent).toBeDefined();
+      expect(typeof result.structuredContent?.scene).toBe('string');
+      expect(Array.isArray(result.structuredContent?.dependencies)).toBe(true);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/tests/unit/handlers/node-handlers.test.ts
+++ b/tests/unit/handlers/node-handlers.test.ts
@@ -367,7 +367,11 @@ describe('handleAttachScript', () => {
 
   it('returns parsed result on successful runner output', async () => {
     const fake = createFakeRunner({
-      stdout: "Script 'res://placeholder.gd' attached successfully to node 'root/Sprite2D'",
+      stdout: JSON.stringify({
+        success: true,
+        nodePath: 'root/Sprite2D',
+        scriptPath: 'placeholder.gd',
+      }),
     });
     const result = await handleAttachScript(fake.asRunner, {
       ...validBase,
@@ -375,8 +379,16 @@ describe('handleAttachScript', () => {
       scriptPath: 'placeholder.gd',
     });
     expect(hasError(result)).toBe(false);
-    const text = (result as { content: Array<{ text: string }> }).content[0].text;
-    expect(text).toContain('attached successfully');
+    const typed = result as {
+      content: Array<{ text: string }>;
+      structuredContent?: { success?: boolean; nodePath?: string; scriptPath?: string };
+    };
+    expect(typed.structuredContent).toEqual({
+      success: true,
+      nodePath: 'root/Sprite2D',
+      scriptPath: 'placeholder.gd',
+    });
+    expect(JSON.parse(typed.content[0].text)).toEqual(typed.structuredContent);
   });
 });
 
@@ -513,15 +525,27 @@ describe('handleDuplicateNode', () => {
 
   it('returns parsed result on successful runner output', async () => {
     const fake = createFakeRunner({
-      stdout: "Node duplicated successfully as 'Sprite2D2'",
+      stdout: JSON.stringify({
+        success: true,
+        originalPath: 'root/Sprite2D',
+        newPath: 'root/Sprite2D2',
+      }),
     });
     const result = await handleDuplicateNode(fake.asRunner, {
       ...validBase,
       nodePath: 'root/Sprite2D',
     });
     expect(hasError(result)).toBe(false);
-    const text = (result as { content: Array<{ text: string }> }).content[0].text;
-    expect(text).toContain('duplicated successfully');
+    const typed = result as {
+      content: Array<{ text: string }>;
+      structuredContent?: { success?: boolean; originalPath?: string; newPath?: string };
+    };
+    expect(typed.structuredContent).toEqual({
+      success: true,
+      originalPath: 'root/Sprite2D',
+      newPath: 'root/Sprite2D2',
+    });
+    expect(JSON.parse(typed.content[0].text)).toEqual(typed.structuredContent);
   });
 });
 

--- a/tests/unit/handlers/runtime-handlers.test.ts
+++ b/tests/unit/handlers/runtime-handlers.test.ts
@@ -800,7 +800,8 @@ describe('handleRunScript', () => {
     const parsed = JSON.parse((result as { content: Array<{ text: string }> }).content[0].text);
     expect(parsed.success).toBe(true);
     expect(parsed.result).toBeNull();
-    expect(parsed.warning).toMatch(/GDScript does not propagate exceptions/);
+    expect(Array.isArray(parsed.warnings)).toBe(true);
+    expect(parsed.warnings[0]).toMatch(/GDScript does not propagate exceptions/);
   });
 
   it('returns success without escalation when attached + result:null (stderr not captured)', async () => {

--- a/tests/unit/handlers/scene-handlers.test.ts
+++ b/tests/unit/handlers/scene-handlers.test.ts
@@ -75,14 +75,23 @@ describe('handleCreateScene', () => {
   });
 
   it('returns parsed result on successful runner output', async () => {
-    const fake = createFakeRunner({ stdout: 'Scene created successfully at: scenes/x.tscn' });
+    const fake = createFakeRunner({
+      stdout: JSON.stringify({ success: true, scenePath: 'scenes/x.tscn' }),
+    });
     const result = await handleCreateScene(fake.asRunner, {
       projectPath: fixtureProjectPath,
       scenePath: 'scenes/x.tscn',
     });
     expect(hasError(result)).toBe(false);
-    const text = (result as { content: Array<{ text: string }> }).content[0].text;
-    expect(text).toContain('created successfully');
+    const typed = result as {
+      content: Array<{ text: string }>;
+      structuredContent?: { success?: boolean; scenePath?: string };
+    };
+    expect(typed.structuredContent).toEqual({ success: true, scenePath: 'scenes/x.tscn' });
+    expect(JSON.parse(typed.content[0].text)).toEqual({
+      success: true,
+      scenePath: 'scenes/x.tscn',
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #18. MCP spec 2025-06-18 requires tools with `outputSchema` to return matching `structuredContent`; strict clients (LM Studio, Open Code, AnythingLLM) reject responses without it. Claude Code is lenient, which hid the regression.

## Changes
- New `createStructuredResponse` helper in `godot-runner.ts` — emits payload as JSON text block (lenient clients) **and** `structuredContent` (strict clients).
- `executeSceneOp` gains `parseStdoutAsJson` option that wraps GDScript JSON output the same way.
- Fixed three drift tools whose GDScript emitted plain-text strings while their schemas declared structured objects: `create_scene`, `attach_script`, `duplicate_node` now emit JSON matching their schemas.
- Standardized `run_script` on `warnings` array (dropped the warning-string variant from schema + inline branch).
- New `tests/integration/mcp-output-schema.test.ts` — strict-client coverage via real `Server`+`Client` over `InMemoryTransport`.
- Bump to 3.1.2.

## Test plan
- [x] `npm run verify` green
- [x] `GODOT_PATH=D:/Godot/latest/godot.exe npm test` — 810 pass, 1 platform-conditional skip