### PR TITLE
fix(bridge): force-draw screenshots when window occluded to avoid macOS hang

### DIFF
--- a/src/scripts/mcp_bridge.gd
+++ b/src/scripts/mcp_bridge.gd
@@ -181,7 +181,7 @@ func _dispatch_command(peer: PeerState, data: String) -> void:
 # --- Screenshot ---
 
 func _handle_screenshot(peer: PeerState, payload: Dictionary = {}) -> void:
-	await RenderingServer.frame_post_draw
+	await _ensure_frame_rendered()
 
 	var viewport := get_viewport()
 	if viewport == null:
@@ -234,6 +234,37 @@ func _handle_screenshot(peer: PeerState, payload: Dictionary = {}) -> void:
 		response["preview_height"] = preview_height
 
 	_send_response(peer, response)
+
+# Waits until a freshly rendered frame is available for capture.
+#
+# Normal path: the engine's render loop is presenting every frame, so the
+# next frame_post_draw is imminent. Occluded path (macOS-only today): a
+# background-mode window parked off-screen fails NSWindowOcclusionState
+# visibility, DisplayServer.window_can_draw() goes false, and the engine
+# main loop stops calling RenderingServer.draw() entirely, so
+# frame_post_draw never fires and the await would deadlock the peer.
+# Recover by driving one render manually: force_draw(false) renders every
+# viewport into its render target but skips the swapchain blit that hangs
+# while occluded. See issue #24.
+func _ensure_frame_rendered() -> void:
+	if DisplayServer.window_can_draw():
+		await RenderingServer.frame_post_draw
+		return
+	# GDScript lambdas capture locals by value; use an Array so the
+	# mutation inside the lambda is visible out here.
+	var draw_state := [false]
+	var on_draw := func() -> void: draw_state[0] = true
+	# Connect BEFORE force_draw(): with single-threaded rendering (the
+	# default), frame_post_draw fires synchronously inside force_draw(),
+	# before an await here could start listening.
+	RenderingServer.frame_post_draw.connect(on_draw, CONNECT_ONE_SHOT)
+	RenderingServer.force_draw(false, 0.0)
+	if not draw_state[0]:
+		# Threaded rendering: the signal is emitted deferred on the main
+		# thread; resume when it lands.
+		await RenderingServer.frame_post_draw
+	elif RenderingServer.frame_post_draw.is_connected(on_draw):
+		RenderingServer.frame_post_draw.disconnect(on_draw)
 
 # --- Input Simulation ---
 


### PR DESCRIPTION
## Problem

`take_screenshot` hangs forever on macOS when `run_project` was called with `background: true` (#24). Background mode parks the window at `(-9999, -9999)`; macOS's `window_can_draw()` is driven by `NSWindowOcclusionStateVisible`, which goes false for a fully off-screen window. `Main::iteration` then skips `RenderingServer::draw()` entirely, so `frame_post_draw` never fires, `_handle_screenshot`'s await never resumes, and the bridge peer deadlocks (`peer.handling` stays true forever). Windows/Linux gate only on minimized state and are unaffected.

Root cause was traced through Godot source and independently re-verified (`main.cpp` draw gate, per-platform `can_any_window_draw()`, `godot_window_delegate.mm` occlusion handler, `renderer_viewport.cpp` blit gating).

## Fix

New `_ensure_frame_rendered()` helper in `mcp_bridge.gd`:

- `window_can_draw()` true: identical to today's behavior (await `frame_post_draw`). Windows/Linux code path is unchanged.
- Occluded: drive one render manually with `RenderingServer.force_draw(false, 0.0)` - renders all viewports fresh but skips the swapchain blit that stalls while occluded. This restores **live** capture (screenshots reflect `simulate_input` taken while backgrounded) rather than just un-hanging with a stale texture.

Two correctness details baked in:
- The completion flag lives in an `Array` because GDScript lambdas capture locals **by value**; with single-threaded rendering (the default) `frame_post_draw` fires synchronously inside `force_draw()`, and a plain local flag would silently stay false and re-deadlock.
- The signal is connected `CONNECT_ONE_SHOT` **before** `force_draw()` for the same synchronous-emit reason.

## Verification

- `npm run verify` green with `GODOT_PATH` set (typecheck, lint, format, 1006 tests, build)
- Modified script passes Godot 4.5.1 headless parse validation
- On-Mac validation of the occluded path is pending (being tested against real Apple Silicon + Metal now); engine-source analysis says the forced draw never touches the blocking presentation path

Fixes #24