### PR TITLE
fix(runtime): resolve relative projectPath in run_project and attach_…

### DIFF
--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -945,6 +945,9 @@ export async function handleRunProject(
         : '';
       const lines = [
         `${racePrefix}Godot process started, but the MCP bridge did not respond within ${BRIDGE_WAIT_SPAWNED_TIMEOUT_MS / 1000} seconds.`,
+        // Surface the precise poll failure (token/path mismatch, abort reason)
+        // instead of burying it behind the generic timeout narrative.
+        ...(bridgeResult.error ? [`- Actual reason: ${bridgeResult.error}`] : []),
         '- The bridge listener never came up — likely an early _ready error or a stuck process holding the port',
         '- Session has been torn down; retry run_project to start a new one',
         errorTail,

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'url';
-import { join, dirname, normalize } from 'path';
+import { join, dirname, normalize, resolve } from 'path';
 import { existsSync } from 'fs';
 import type { ChildProcess, SpawnOptions } from 'child_process';
 import { spawn } from 'child_process';
@@ -415,6 +415,12 @@ export class GodotRunner {
       );
     }
 
+    // Resolve relative paths (e.g. ".") to absolute against the server's cwd.
+    // The bridge reports an absolute project_path in its pong, so a relative
+    // expectedPath makes pollBridge's path guard fail immediately and mask
+    // the real reason as a generic bridge timeout.
+    projectPath = resolve(projectPath);
+
     if (this.activeSessionMode === 'spawned' && this.activeProcess) {
       logDebug('Killing existing Godot process before starting a new one');
       this.closeConnection();
@@ -520,6 +526,9 @@ export class GodotRunner {
   }
 
   async attachProject(projectPath: string, bridgePort?: number): Promise<void> {
+    // Resolve relative paths for the same reason as runProject — pollBridge
+    // compares against the absolute path the bridge reports.
+    projectPath = resolve(projectPath);
     if (this.activeSessionMode === 'spawned' && this.activeProcess) {
       await this.stopProject();
     } else if (

--- a/tests/unit/relative-project-path.test.ts
+++ b/tests/unit/relative-project-path.test.ts
@@ -1,28 +1,41 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { resolve } from 'path';
 import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, resolve } from 'path';
 
-const spawnMock = vi.fn();
-const findFreePortMock = vi.fn(async () => 12345);
-const injectMock = vi.fn();
-const cleanupMock = vi.fn();
+const { MOCK_BRIDGE_PORT, spawnMock, findFreePortMock, injectMock, cleanupMock } = vi.hoisted(
+  () => {
+    const port = 12345;
+    return {
+      MOCK_BRIDGE_PORT: port,
+      spawnMock: vi.fn(),
+      findFreePortMock: vi.fn(async () => port),
+      injectMock: vi.fn(),
+      cleanupMock: vi.fn(),
+    };
+  },
+);
 
-vi.mock('child_process', () => ({ spawn: (...args: unknown[]) => spawnMock(...args) }));
-vi.mock('./bridge-protocol.js', async () => {
-  const actual = await vi.importActual('./bridge-protocol.js');
+// Specifiers resolve relative to THIS file, so they must name the same module
+// ids godot-runner.ts imports. A mismatch binds nothing, silently, and the real
+// implementation runs instead.
+vi.mock('child_process', async () => ({
+  ...(await vi.importActual('child_process')),
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+vi.mock('../../src/utils/bridge-protocol.js', async () => {
+  const actual = await vi.importActual('../../src/utils/bridge-protocol.js');
   return { ...actual, findFreePort: findFreePortMock };
 });
-vi.mock('./path-validation.js', async () => {
-  const actual = await vi.importActual('./path-validation.js');
+vi.mock('../../src/utils/path-validation.js', async () => {
+  const actual = await vi.importActual('../../src/utils/path-validation.js');
   return { ...actual, checkDisplayAvailable: () => true, validateSubPath: () => false };
 });
-vi.mock('./bridge-manager.js', () => ({
+vi.mock('../../src/utils/bridge-manager.js', () => ({
   BridgeManager: class {
     inject = injectMock;
     cleanup = cleanupMock;
-    getLastInjectedPort = () => 12345;
+    getLastInjectedPort = () => MOCK_BRIDGE_PORT;
   },
 }));
 
@@ -66,6 +79,8 @@ describe('runProject relative projectPath regression', () => {
       const spawnArgs = spawnMock.mock.calls[0] as unknown[];
       expect(spawnArgs[1]).toContain('--path');
       expect(spawnArgs[1]).toContain(resolve('.'));
+      expect(injectMock).toHaveBeenCalled();
+      expect(runner.activeBridgePort).toBe(MOCK_BRIDGE_PORT);
     } finally {
       process.chdir(cwdSave);
     }
@@ -77,5 +92,25 @@ describe('runProject relative projectPath regression', () => {
     expect(runner.activeProjectPath).toBe(resolve(projectDir));
     const spawnArgs = spawnMock.mock.calls[0] as unknown[];
     expect(spawnArgs[1]).toContain(resolve(projectDir));
+    expect(injectMock).toHaveBeenCalled();
+    expect(runner.activeBridgePort).toBe(MOCK_BRIDGE_PORT);
+  });
+
+  // CI runs the unit suite on ubuntu-latest with no xvfb, where the real
+  // checkDisplayAvailable() rejects the launch. Fake it so an unbound
+  // path-validation mock fails here instead of only in CI.
+  it('runs under headless-CI conditions (linux, no DISPLAY)', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    vi.stubEnv('DISPLAY', undefined);
+    vi.stubEnv('WAYLAND_DISPLAY', undefined);
+    try {
+      const runner = new GodotRunner({ godotPath: process.execPath });
+      await expect(runner.runProject(projectDir, undefined, true)).resolves.toBeDefined();
+      expect(runner.activeProjectPath).toBe(resolve(projectDir));
+    } finally {
+      vi.unstubAllEnvs();
+      if (platformDescriptor) Object.defineProperty(process, 'platform', platformDescriptor);
+    }
   });
 });

--- a/tests/unit/relative-project-path.test.ts
+++ b/tests/unit/relative-project-path.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolve } from 'path';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const spawnMock = vi.fn();
+const findFreePortMock = vi.fn(async () => 12345);
+const injectMock = vi.fn();
+const cleanupMock = vi.fn();
+
+vi.mock('child_process', () => ({ spawn: (...args: unknown[]) => spawnMock(...args) }));
+vi.mock('./bridge-protocol.js', async () => {
+  const actual = await vi.importActual('./bridge-protocol.js');
+  return { ...actual, findFreePort: findFreePortMock };
+});
+vi.mock('./path-validation.js', async () => {
+  const actual = await vi.importActual('./path-validation.js');
+  return { ...actual, checkDisplayAvailable: () => true, validateSubPath: () => false };
+});
+vi.mock('./bridge-manager.js', () => ({
+  BridgeManager: class {
+    inject = injectMock;
+    cleanup = cleanupMock;
+    getLastInjectedPort = () => 12345;
+  },
+}));
+
+import { GodotRunner } from '../../src/utils/godot-runner.js';
+
+function fakeSpawnedProcess() {
+  return {
+    pid: 4242,
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+  };
+}
+
+describe('runProject relative projectPath regression', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'gmr-rel-path-'));
+    writeFileSync(join(projectDir, 'project.godot'), '[application]');
+    spawnMock.mockReset().mockReturnValue(fakeSpawnedProcess());
+    injectMock.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('stores the absolute path so pollBridge can match the bridge-reported project_path', async () => {
+    // Regression: with a relative path ('.'), waitForBridge's path guard
+    // compared the bridge-reported absolute project_path against '.' and
+    // failed instantly — misreported as a generic 8s bridge timeout.
+    const cwdSave = process.cwd();
+    process.chdir(projectDir);
+    try {
+      const runner = new GodotRunner({ godotPath: process.execPath });
+      await runner.runProject('.', undefined, true);
+      expect(runner.activeProjectPath).toBe(resolve('.'));
+      // spawn argv carries the resolved path — Godot loads the project from it
+      const spawnArgs = spawnMock.mock.calls[0] as unknown[];
+      expect(spawnArgs[1]).toContain('--path');
+      expect(spawnArgs[1]).toContain(resolve('.'));
+    } finally {
+      process.chdir(cwdSave);
+    }
+  });
+
+  it('keeps absolute paths unchanged', async () => {
+    const runner = new GodotRunner({ godotPath: process.execPath });
+    await runner.runProject(projectDir, undefined, true);
+    expect(runner.activeProjectPath).toBe(resolve(projectDir));
+    const spawnArgs = spawnMock.mock.calls[0] as unknown[];
+    expect(spawnArgs[1]).toContain(resolve(projectDir));
+  });
+});


### PR DESCRIPTION
…project

Relative project paths (e.g. '.') failed pollBridge's path guard: the bridge reports an absolute project_path in its pong, so the comparison against '.' failed instantly and run_project misreported the failure as a generic 8-second bridge timeout (with the real reason discarded).

- Resolve projectPath to absolute at entry of runProject/attachProject
- Surface bridgeResult.error as 'Actual reason: ...' in the run_project failure message instead of masking it
- Add TDD regression test (red on main, green with fix): asserts activeProjectPath and the spawn --path argv are absolute