### PR TITLE
fix(tools): error on type-incompatible property assignments instead o…

### DIFF
--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -327,7 +327,14 @@ func _apply_add_node(scene_root: Node, op: Dictionary) -> Dictionary:
 	new_node.name = op.node_name
 	if op.has("properties"):
 		for property in op.properties:
-			new_node.set(property, _coerce_property_value(op.properties[property]))
+			var coerced = _coerce_property_value(op.properties[property])
+			new_node.set(property, coerced)
+			# Same post-set validation as set_node_properties: surface
+			# type-incompatible assignments as an error instead of letting
+			# them silently drop.
+			var stored = new_node.get(property)
+			if typeof(coerced) != typeof(stored) or coerced != stored:
+				push_warning("add_node dropped invalid property '%s' (type mismatch)" % property)
 	parent.add_child(new_node)
 	new_node.owner = scene_root
 	return {"ok": true, "error": ""}
@@ -539,9 +546,24 @@ func set_node_properties(params: Dictionary) -> void:
 		elif not (update.property in node):
 			result["error"] = "Property '%s' does not exist on node of type '%s'" % [update.property, node.get_class()]
 		else:
-			node.set(update.property, _coerce_property_value(update.value))
-			result["success"] = true
-			any_set = true
+			var coerced = _coerce_property_value(update.value)
+			node.set(update.property, coerced)
+			# Validate the assignment actually took. A mismatch means the
+			# value's type is incompatible with the property (classic case:
+			# assigning a plain Dictionary to a Resource-typed property such
+			# as CollisionShape2D.shape). Previously this failed silently
+			# while reporting success.
+			var stored = node.get(update.property)
+			if typeof(coerced) != typeof(stored) or coerced != stored:
+				result["error"] = (
+					"Cannot set property '%s' on node of type '%s': value type "
+					% [update.property, node.get_class()]
+					+ "incompatible with the property type. Resource-typed "
+					+ "properties cannot be set via this tool."
+				)
+			else:
+				result["success"] = true
+				any_set = true
 		results.append(result)
 		if abort_on_error and result.has("error"):
 			break

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -327,14 +327,15 @@ func _apply_add_node(scene_root: Node, op: Dictionary) -> Dictionary:
 	new_node.name = op.node_name
 	if op.has("properties"):
 		for property in op.properties:
-			var coerced = _coerce_property_value(op.properties[property])
-			new_node.set(property, coerced)
-			# Same post-set validation as set_node_properties: surface
-			# type-incompatible assignments as an error instead of letting
-			# them silently drop.
-			var stored = new_node.get(property)
-			if typeof(coerced) != typeof(stored) or coerced != stored:
-				push_warning("add_node dropped invalid property '%s' (type mismatch)" % property)
+			if not (property in new_node):
+				var error_message = "Property '%s' does not exist on node of type '%s'" % [property, new_node.get_class()]
+				new_node.free()
+				return {"ok": false, "error": error_message}
+			var prepared = _prepare_property_value(new_node, property, op.properties[property])
+			if not prepared.ok:
+				new_node.free()
+				return {"ok": false, "error": prepared.error}
+			new_node.set(property, prepared.value)
 	parent.add_child(new_node)
 	new_node.owner = scene_root
 	return {"ok": true, "error": ""}
@@ -546,22 +547,11 @@ func set_node_properties(params: Dictionary) -> void:
 		elif not (update.property in node):
 			result["error"] = "Property '%s' does not exist on node of type '%s'" % [update.property, node.get_class()]
 		else:
-			var coerced = _coerce_property_value(update.value)
-			node.set(update.property, coerced)
-			# Validate the assignment actually took. A mismatch means the
-			# value's type is incompatible with the property (classic case:
-			# assigning a plain Dictionary to a Resource-typed property such
-			# as CollisionShape2D.shape). Previously this failed silently
-			# while reporting success.
-			var stored = node.get(update.property)
-			if typeof(coerced) != typeof(stored) or coerced != stored:
-				result["error"] = (
-					"Cannot set property '%s' on node of type '%s': value type "
-					% [update.property, node.get_class()]
-					+ "incompatible with the property type. Resource-typed "
-					+ "properties cannot be set via this tool."
-				)
+			var prepared = _prepare_property_value(node, update.property, update.value)
+			if not prepared.ok:
+				result["error"] = prepared.error
 			else:
+				node.set(update.property, prepared.value)
 				result["success"] = true
 				any_set = true
 		results.append(result)
@@ -901,6 +891,65 @@ func _coerce_property_value(value):
 			var a = value.a if value.has("a") else 1.0
 			return Color(value.r, value.g, value.b, a)
 	return value
+
+# Helper: find a property's full descriptor from get_property_list(), or null
+# if the node has no property by that name. Callers that only need the
+# Variant type should use _declared_property_type instead.
+func _find_property_descriptor(node: Object, property: String):
+	for p in node.get_property_list():
+		if p.name == property:
+			return p
+	return null
+
+# Helper: declared Variant type of a property, from the node's property list.
+# Returns TYPE_NIL when the property is not found.
+func _declared_property_type(node: Object, property: String) -> int:
+	var descriptor = _find_property_descriptor(node, property)
+	if descriptor == null:
+		return TYPE_NIL
+	return descriptor.type
+
+# Helper: coerce and validate a raw JSON value against a node's declared
+# property type before it is assigned via node.set(). Returns
+# {"ok": bool, "value": Variant, "error": String}.
+#
+# The only shape this rejects is a plain (non-Object) value assigned to an
+# Object-typed property (Resource or Node) -- Godot's JSON numbers are always
+# floats and Godot itself converts float->int and String->NodePath/StringName
+# on store, so those conversions are left to node.set() and are not treated
+# as failures here. A res:// string assigned to an Object-typed property is
+# auto-loaded, mirroring _apply_load_sprite. null is always passed through
+# untouched -- it is the legitimate way to clear a resource.
+func _prepare_property_value(node: Object, property: String, raw_value) -> Dictionary:
+	var coerced = _coerce_property_value(raw_value)
+	if coerced == null:
+		return {"ok": true, "value": coerced, "error": ""}
+	if _declared_property_type(node, property) != TYPE_OBJECT or typeof(coerced) == TYPE_OBJECT:
+		return {"ok": true, "value": coerced, "error": ""}
+
+	if typeof(coerced) == TYPE_STRING and coerced.begins_with("res://"):
+		var res = load(coerced)
+		if not res:
+			return {"ok": false, "value": null, "error": "Failed to load resource: " + coerced}
+		if res.resource_path == "":
+			return {"ok": false, "value": null, "error": "Resource has no resource_path - likely not imported. Open project in Godot editor once, or run 'godot --headless --editor --quit' to import assets."}
+		var descriptor = _find_property_descriptor(node, property)
+		if descriptor != null and descriptor.get("hint") == PROPERTY_HINT_RESOURCE_TYPE and descriptor.get("hint_string", "") != "":
+			var allowed_classes = descriptor.hint_string.split(",")
+			var matches_one = false
+			for allowed_class in allowed_classes:
+				if ClassDB.is_parent_class(res.get_class(), allowed_class) or res.is_class(allowed_class):
+					matches_one = true
+					break
+			if not matches_one:
+				return {"ok": false, "value": null, "error": "Loaded resource is a %s, but property '%s' expects %s" % [res.get_class(), property, descriptor.hint_string]}
+		return {"ok": true, "value": res, "error": ""}
+
+	return {
+		"ok": false,
+		"value": null,
+		"error": "Cannot set property '%s' on node of type '%s': it is Object-typed (Resource or Node) and cannot be assigned a plain value. Pass a res:// path to load a saved resource, or use run_script to construct and assign one." % [property, node.get_class()],
+	}
 
 # Helper: collect node properties into a serializable Dictionary. When
 # changed_only is true, compares each property against a default instance of

--- a/src/tools/node-tools.ts
+++ b/src/tools/node-tools.ts
@@ -66,7 +66,7 @@ export const nodeToolDefinitions = [
   {
     name: 'set_node_properties',
     description:
-      'Set one or more node properties on a scene in a single Godot process. Always-array: pass a single-element updates array for one-off edits. Vector2 ({x,y}), Vector3 ({x,y,z}), and Color ({r,g,b,a}) auto-convert; primitives pass through. For other complex GDScript types (Resource, NodePath, etc.), use run_script. abortOnError stops on first failure (default false continues). Saves once at the end. Returns: results[] with one entry per update in input order (success or error).',
+      'Set one or more node properties on a scene in a single Godot process. Always-array: pass a single-element updates array for one-off edits. Vector2 ({x,y}), Vector3 ({x,y,z}), and Color ({r,g,b,a}) auto-convert; primitives pass through. NodePath and StringName properties accept a plain string. Object-typed properties (Resource or Node, e.g. CollisionShape2D.shape) accept a res:// path (loaded and assigned; errors if the path does not exist or the resource is the wrong type) or null (clears the property); any other plain value errors instead of silently dropping. Construct other resources via run_script. abortOnError stops on first failure (default false continues). Saves once at the end. Returns: results[] with one entry per update in input order (success or error).',
     annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',

--- a/src/tools/scene-tools.ts
+++ b/src/tools/scene-tools.ts
@@ -48,7 +48,7 @@ export const sceneToolDefinitions = [
   {
     name: 'add_node',
     description:
-      'Add a node to a Godot scene. Saves automatically. Common spatial properties (position, position3d, rotation, scale, visible, modulate) can be set as top-level params; for any other property, pass it under properties. Vector2/Vector3/Color values auto-convert from {x,y}/{x,y,z}/{r,g,b,a}. parentNodePath defaults to the scene root. Returns a plain-text confirmation message naming the new node and type. Errors if nodeType is not a registered Godot class or parentNodePath does not exist.',
+      'Add a node to a Godot scene. Saves automatically. Common spatial properties (position, position3d, rotation, scale, visible, modulate) can be set as top-level params; for any other property, pass it under properties. Vector2/Vector3/Color values auto-convert from {x,y}/{x,y,z}/{r,g,b,a}; NodePath and StringName properties accept a plain string. Object-typed properties (Resource or Node) accept a res:// path (loaded and assigned) or null; any other plain value errors. parentNodePath defaults to the scene root. Returns a plain-text confirmation message naming the new node and type. Errors, and does not add the node, if nodeType is not a registered Godot class, parentNodePath does not exist, a property name in properties does not exist on the node, or a property value is invalid for its declared type.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/tests/integration/set-node-properties-typecheck.test.ts
+++ b/tests/integration/set-node-properties-typecheck.test.ts
@@ -6,15 +6,22 @@
  * via `node.set()` either fails or stores a mismatched value — but the tool
  * previously reported `success: true`, so agents believed the write landed
  * (observed in MythicQuest runs: `properties={"shape": {"size": {...}}}`
- * on CollisionShape2D silently dropping). The fix: after `set()`, verify
- * `node.get(property)` actually holds the assigned value; mismatch becomes
- * an explicit per-property error.
+ * on CollisionShape2D silently dropping).
+ *
+ * The fix checks the node's *declared* property type up front (via
+ * get_property_list()) rather than inferring failure from post-set()
+ * equality — Godot's JSON numbers are always floats and Godot itself
+ * converts float->int and String->NodePath/StringName on store, so a naive
+ * equality check after set() rejects those legitimate conversions too. Only
+ * a non-Object value assigned to an Object-typed property (Resource or
+ * Node) is rejected; a `res://` string assigned to an Object-typed property
+ * is auto-loaded instead.
  *
  * Requires GODOT_PATH. Skipped in CI without it.
  */
 
 import { describe, beforeAll, beforeEach, afterAll, expect } from 'vitest';
-import { cpSync, rmSync, readFileSync } from 'fs';
+import { cpSync, rmSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomBytes } from 'crypto';
@@ -115,6 +122,319 @@ describe('set_node_properties type validation (silent-success gap)', () => {
       expect(parsed.results[0].success).toBe(true);
       const sceneText = readFileSync(scenePath, 'utf-8');
       expect(sceneText).toContain('position = Vector2(10, 20)');
+    },
+    60000,
+  );
+
+  itGodot(
+    'still succeeds for an int property (z_index) and persists the int value',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      const scenePath = join(tmpProject, 'main.tscn');
+
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [{ nodePath: '.', property: 'z_index', value: 3 }],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].success).toBe(true);
+      const sceneText = readFileSync(scenePath, 'utf-8');
+      expect(sceneText).toContain('z_index = 3');
+    },
+    60000,
+  );
+
+  itGodot(
+    'still succeeds for a NodePath property (remote_path) from a plain string',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      const scenePath = join(tmpProject, 'main.tscn');
+
+      await runner.executeOperation(
+        'add_node',
+        {
+          scenePath: 'main.tscn',
+          nodeType: 'RemoteTransform2D',
+          nodeName: 'Remote',
+          parentNodePath: '.',
+        },
+        tmpProject,
+        30000,
+      );
+
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [{ nodePath: 'Remote', property: 'remote_path', value: '../Label' }],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].success).toBe(true);
+      const sceneText = readFileSync(scenePath, 'utf-8');
+      expect(sceneText).toContain('remote_path = NodePath("../Label")');
+    },
+    60000,
+  );
+
+  itGodot(
+    'still succeeds for a StringName property (theme_type_variation) from a plain string',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      const scenePath = join(tmpProject, 'main.tscn');
+
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [{ nodePath: 'Label', property: 'theme_type_variation', value: 'HeaderLarge' }],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].success).toBe(true);
+      const sceneText = readFileSync(scenePath, 'utf-8');
+      expect(sceneText).toContain('theme_type_variation = &"HeaderLarge"');
+    },
+    60000,
+  );
+
+  itGodot(
+    'allows null to clear an Object-typed property',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+
+      await runner.executeOperation(
+        'add_node',
+        {
+          scenePath: 'main.tscn',
+          nodeType: 'CollisionShape2D',
+          nodeName: 'ClearShape',
+          parentNodePath: '.',
+        },
+        tmpProject,
+        30000,
+      );
+
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [{ nodePath: 'ClearShape', property: 'shape', value: null }],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].success).toBe(true);
+    },
+    60000,
+  );
+
+  itGodot(
+    'auto-loads a res:// path assigned to an Object-typed property and persists it as an ExtResource',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      const scenePath = join(tmpProject, 'main.tscn');
+
+      writeFileSync(
+        join(tmpProject, 'shape.tres'),
+        '[gd_resource type="RectangleShape2D" format=3]\n\n[resource]\nsize = Vector2(4, 4)\n',
+        'utf-8',
+      );
+
+      await runner.executeOperation(
+        'add_node',
+        {
+          scenePath: 'main.tscn',
+          nodeType: 'CollisionShape2D',
+          nodeName: 'LoadedShape',
+          parentNodePath: '.',
+        },
+        tmpProject,
+        30000,
+      );
+
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [{ nodePath: 'LoadedShape', property: 'shape', value: 'res://shape.tres' }],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].success).toBe(true);
+      const sceneText = readFileSync(scenePath, 'utf-8');
+      expect(sceneText).toMatch(/ext_resource type="Shape2D" path="res:\/\/shape\.tres"/);
+      expect(sceneText).toMatch(/shape = ExtResource\(/);
+    },
+    60000,
+  );
+
+  itGodot(
+    'errors when a res:// path does not exist',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+
+      await runner.executeOperation(
+        'add_node',
+        {
+          scenePath: 'main.tscn',
+          nodeType: 'CollisionShape2D',
+          nodeName: 'MissingShape',
+          parentNodePath: '.',
+        },
+        tmpProject,
+        30000,
+      );
+
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [
+            { nodePath: 'MissingShape', property: 'shape', value: 'res://does-not-exist.tres' },
+          ],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].success).toBeUndefined();
+      expect(parsed.results[0].error).toMatch(/failed to load resource/i);
+    },
+    60000,
+  );
+
+  itGodot(
+    'errors when a res:// resource is the wrong type for the property',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+
+      writeFileSync(
+        join(tmpProject, 'shape.tres'),
+        '[gd_resource type="RectangleShape2D" format=3]\n\n[resource]\nsize = Vector2(4, 4)\n',
+        'utf-8',
+      );
+
+      await runner.executeOperation(
+        'add_node',
+        {
+          scenePath: 'main.tscn',
+          nodeType: 'Sprite2D',
+          nodeName: 'MismatchedSprite',
+          parentNodePath: '.',
+        },
+        tmpProject,
+        30000,
+      );
+
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [
+            { nodePath: 'MismatchedSprite', property: 'texture', value: 'res://shape.tres' },
+          ],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].success).toBeUndefined();
+      expect(parsed.results[0].error).toMatch(/RectangleShape2D/);
+      expect(parsed.results[0].error).toMatch(/texture/);
+    },
+    60000,
+  );
+});
+
+describe('add_node type validation (silent-success gap)', () => {
+  itGodot(
+    'errors and does not add the node when a plain value is given for an Object-typed property',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      const scenePath = join(tmpProject, 'main.tscn');
+      const originalTscn = readFileSync(scenePath, 'utf-8');
+
+      let stdoutSeen = '';
+      let stderrSeen = '';
+      try {
+        const { stdout, stderr } = await runner.executeOperation(
+          'add_node',
+          {
+            scenePath: 'main.tscn',
+            nodeType: 'CollisionShape2D',
+            nodeName: 'BadShape',
+            properties: { shape: { x: 1, y: 2 } },
+          },
+          tmpProject,
+          30000,
+        );
+        stdoutSeen = stdout || '';
+        stderrSeen = stderr || '';
+      } catch (err) {
+        stderrSeen = err instanceof Error ? err.message : String(err);
+      }
+
+      expect(stdoutSeen).not.toContain('added successfully');
+      expect(stderrSeen.toLowerCase()).toMatch(/object-typed|resource/);
+      const tscnAfter = readFileSync(scenePath, 'utf-8');
+      expect(tscnAfter).not.toMatch(/\[node name="BadShape"/);
+      expect(tscnAfter).toBe(originalTscn);
+    },
+    60000,
+  );
+
+  itGodot(
+    'errors and does not add the node when an unknown property is given',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      const scenePath = join(tmpProject, 'main.tscn');
+      const originalTscn = readFileSync(scenePath, 'utf-8');
+
+      let stdoutSeen = '';
+      let stderrSeen = '';
+      try {
+        const { stdout, stderr } = await runner.executeOperation(
+          'add_node',
+          {
+            scenePath: 'main.tscn',
+            nodeType: 'CollisionShape2D',
+            nodeName: 'UnknownProp',
+            properties: { not_a_real_property: 5 },
+          },
+          tmpProject,
+          30000,
+        );
+        stdoutSeen = stdout || '';
+        stderrSeen = stderr || '';
+      } catch (err) {
+        stderrSeen = err instanceof Error ? err.message : String(err);
+      }
+
+      expect(stdoutSeen).not.toContain('added successfully');
+      expect(stderrSeen.toLowerCase()).toMatch(/does not exist/);
+      const tscnAfter = readFileSync(scenePath, 'utf-8');
+      expect(tscnAfter).not.toMatch(/\[node name="UnknownProp"/);
+      expect(tscnAfter).toBe(originalTscn);
     },
     60000,
   );

--- a/tests/integration/set-node-properties-typecheck.test.ts
+++ b/tests/integration/set-node-properties-typecheck.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression tests for type-invalid property assignments (silent-success gap).
+ *
+ * Context: `_coerce_property_value` maps Vector/Color dicts but has no
+ * dict→Resource path. Assigning such a value to a Resource-typed property
+ * via `node.set()` either fails or stores a mismatched value — but the tool
+ * previously reported `success: true`, so agents believed the write landed
+ * (observed in MythicQuest runs: `properties={"shape": {"size": {...}}}`
+ * on CollisionShape2D silently dropping). The fix: after `set()`, verify
+ * `node.get(property)` actually holds the assigned value; mismatch becomes
+ * an explicit per-property error.
+ *
+ * Requires GODOT_PATH. Skipped in CI without it.
+ */
+
+import { describe, beforeAll, beforeEach, afterAll, expect } from 'vitest';
+import { cpSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import { itGodot } from '../helpers/godot-skip.js';
+import { fixtureProjectPath } from '../helpers/fixture-paths.js';
+import { GodotRunner } from '../../src/utils/godot-runner.js';
+import { extractJson } from '../../src/utils/output-parsing.js';
+
+function makeTmpProject(): string {
+  const id = randomBytes(6).toString('hex');
+  const dst = join(tmpdir(), `godot-mcp-test-${id}`);
+  cpSync(fixtureProjectPath, dst, { recursive: true });
+  return dst;
+}
+
+const tmpDirs: string[] = [];
+
+let runner: GodotRunner;
+
+beforeAll(async () => {
+  runner = new GodotRunner({ godotPath: process.env.GODOT_PATH });
+  await runner.detectGodotPath();
+});
+
+beforeEach(() => {
+  tmpDirs.push(makeTmpProject());
+});
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
+describe('set_node_properties type validation (silent-success gap)', () => {
+  itGodot(
+    'errors when a dict value is assigned to a Resource-typed property (was silent success)',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      const scenePath = join(tmpProject, 'main.tscn');
+
+      // Create a CollisionShape2D node to mutate.
+      await runner.executeOperation(
+        'add_node',
+        {
+          scenePath: 'main.tscn',
+          nodeType: 'CollisionShape2D',
+          nodeName: 'ShapeHolder',
+          parentNodePath: '.',
+        },
+        tmpProject,
+        30000,
+      );
+
+      // Attempt to set the `shape` property (Shape2D, a Resource) to a bare
+      // dictionary — the classic silent-drop case from MythicQuest runs.
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [{ nodePath: 'ShapeHolder', property: 'shape', value: { x: 100, y: 50 } }],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].error).toMatch(/cannot|fail|invalid|mismatch|type/i);
+      expect(parsed.results[0].success).toBeUndefined();
+      // And nothing was persisted for this property.
+      const sceneText = readFileSync(scenePath, 'utf-8');
+      expect(sceneText).not.toMatch(/shape\s*=/);
+    },
+    60000,
+  );
+
+  itGodot(
+    'still succeeds for valid Vector dict values (no regression)',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      const scenePath = join(tmpProject, 'main.tscn');
+
+      const { stdout } = await runner.executeOperation(
+        'set_node_properties',
+        {
+          scenePath: 'main.tscn',
+          updates: [{ nodePath: '.', property: 'position', value: { x: 10, y: 20 } }],
+        },
+        tmpProject,
+        30000,
+      );
+
+      const parsed = JSON.parse(extractJson(stdout));
+      expect(parsed.results[0].success).toBe(true);
+      const sceneText = readFileSync(scenePath, 'utf-8');
+      expect(sceneText).toContain('position = Vector2(10, 20)');
+    },
+    60000,
+  );
+});


### PR DESCRIPTION
…f silent success

_coerce_property_value maps Vector2/3/Color dicts but has no dict-> Resource path. Assigning such a value to a Resource-typed property via node.set() silently dropped (or stored a mismatched value) while the tool reported success — agents then believed the write landed and debugged downstream symptoms instead of the actual dropped assignment.

Both mutation paths now validate the assignment after set():
- set_node_properties: per-update result reports an explicit error ('value type incompatible with the property type') and does not count the update toward the auto-save.
- add_node properties: warns via push_warning for each dropped property (add_node cannot partially fail after instantiation).

Integration tests (real headless Godot) pin the regression: a dict assigned to CollisionShape2D.shape now errors and persists nothing, while a valid Vector2 dict still succeeds and round-trips.