### PR TITLE
fix(runtime): emit progress heartbeats so client timeouts reset on long tool calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { startProgressHeartbeat } from './utils/progress-heartbeat.js';
 
 import type { GodotServerConfig } from './utils/godot-runner.js';
 import { GodotRunner } from './utils/godot-runner.js';
@@ -144,13 +145,22 @@ class GodotMcpServer {
       tools: allToolDefinitions,
     }));
 
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
       const toolName = request.params.name;
       const args = request.params.arguments || {};
 
       console.error(`[SERVER] Handling tool request: ${toolName}`);
 
-      return await dispatchToolCall(this.runner, toolName, args, this.ctx);
+      // Heartbeat progress notifications for the lifetime of the call so
+      // clients that set `resetTimeoutOnProgress` (e.g. opencode) keep their
+      // request timeout alive across long tool executions (run_script sims,
+      // playtests) instead of failing at the SDK's 60s default.
+      const stopHeartbeat = startProgressHeartbeat(extra, request);
+      try {
+        return await dispatchToolCall(this.runner, toolName, args, this.ctx);
+      } finally {
+        stopHeartbeat();
+      }
     });
   }
 

--- a/src/utils/progress-heartbeat.ts
+++ b/src/utils/progress-heartbeat.ts
@@ -1,0 +1,81 @@
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type { CallToolRequest, Notification } from '@modelcontextprotocol/sdk/types.js';
+
+import { logDebug } from './logger.js';
+
+/**
+ * Interval between progress heartbeat notifications. The MCP spec lets
+ * clients impose a per-request timeout (the SDK default is 60s) and reset it
+ * when `resetTimeoutOnProgress` is set, but ONLY when the server sends
+ * progress notifications. Long-running tools (run_script simulations,
+ * playtests) routinely exceed 60s, so the server heartbeats to keep the
+ * request alive for clients that opted in. Clients that did not opt in
+ * ignore the notifications (their timeout behavior is unchanged).
+ *
+ * 20s gives 3 heartbeats per SDK-default 60s client timeout window.
+ */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 20_000;
+
+/**
+ * Extract the progress token a client attached to a tools/call request
+ * (present only when the client registered an `onprogress` handler — the
+ * SDK sends `_meta.progressToken` only then).
+ */
+export function progressTokenFrom(request: CallToolRequest): string | number | undefined {
+  const token = (request.params as { _meta?: { progressToken?: string | number } })._meta
+    ?.progressToken;
+  return token;
+}
+
+/**
+ * Start sending progress heartbeats for an in-flight tools/call request.
+ *
+ * Returns a stop function that MUST be called when the handler settles
+ * (success or error); it is safe to call more than once and safe to call on
+ * a heartbeat that never started (no token → no-op stopper).
+ */
+export function startProgressHeartbeat(
+  extra: RequestHandlerExtra<never, Notification>,
+  request: CallToolRequest,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): () => void {
+  const token = progressTokenFrom(request);
+  if (token === undefined) {
+    return () => {};
+  }
+
+  let progress = 0;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+
+  const beat = (): void => {
+    if (stopped) return;
+    progress += 1;
+    extra
+      .sendNotification({
+        method: 'notifications/progress',
+        params: {
+          progressToken: token,
+          progress,
+        },
+      })
+      .catch((err: unknown) => {
+        // A failed heartbeat (transport hiccup, unsupported notification)
+        // must never fail the tool call itself. The client that opted in will
+        // surface its own timeout if heartbeats stop arriving.
+        logDebug(`Progress heartbeat failed (continuing): ${String(err)}`);
+      });
+  };
+
+  // Fire immediately, then on the interval — a tool finishing inside one
+  // interval still notifies at least once so clients see liveness from the
+  // first moment.
+  beat();
+  timer = setInterval(beat, intervalMs);
+
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    if (timer !== null) clearInterval(timer);
+  };
+}

--- a/tests/integration/progress-heartbeat.test.ts
+++ b/tests/integration/progress-heartbeat.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Integration test for the progress-heartbeat fix.
+ *
+ * Context: MCP clients may impose a per-request timeout (SDK default 60s;
+ * opencode uses 30s-60s) and honor `resetTimeoutOnProgress` — resetting the
+ * timer each time the server sends a `notifications/progress` for the
+ * request's progress token. Without server-side heartbeats, long-running
+ * tools (run_script playtest simulations routinely run 60s+) die with
+ * `MCP error -32001 Request timed out` even when the tool's own `timeout`
+ * parameter would have allowed them to finish.
+ *
+ * This test wires the real lower-level `Server` with the production
+ * CallToolRequest handler shape (heartbeat wrapper around dispatchToolCall)
+ * to a real `Client` over an in-memory transport, and verifies:
+ *  1. A tool slower than the client timeout completes when the client
+ *     resets on progress (heartbeats arrive on the progress token).
+ *  2. The heartbeat stops when the tool settles (no stray notifications).
+ *  3. Requests without a progress token never send notifications.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  CallToolRequestSchema,
+  CallToolResultSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { startProgressHeartbeat } from '../../src/utils/progress-heartbeat.js';
+import type { ToolResponse } from '../../src/mcp.types.js';
+
+const TICK = 25;
+
+function makeServer(handler: (args: Record<string, unknown>) => Promise<unknown>) {
+  const server = new Server(
+    { name: 'heartbeat-test-server', version: '0.0.0' },
+    { capabilities: { tools: {} } },
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    const stop = startProgressHeartbeat(extra, request, TICK);
+    try {
+      const result = await handler(request.params.arguments || {});
+      return result as ToolResponse;
+    } finally {
+      stop();
+    }
+  });
+  return server;
+}
+
+async function link(server: Server) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'heartbeat-test-client', version: '0.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('progress heartbeat keeps long tool calls alive (issue: -32001 on run_script >60s)', () => {
+  it('completes a tool slower than the client timeout when the client resets on progress', async () => {
+    const server = makeServer(async () => {
+      // Simulated long tool: ~4 heartbeat intervals.
+      await sleep(TICK * 4);
+      return { content: [{ type: 'text', text: 'done' }] };
+    });
+    const client = await link(server);
+    // Silence the expected progress callbacks (they assert nothing).
+    const onprogress = vi.fn();
+
+    try {
+      const result = await client.callTool(
+        { name: 'slow_tool', arguments: {} },
+        CallToolResultSchema,
+        {
+          timeout: TICK * 2,
+          resetTimeoutOnProgress: true,
+          onprogress,
+        },
+      );
+      expect(JSON.stringify(result)).toContain('done');
+      expect(onprogress).toHaveBeenCalled();
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('still times out when the client supplied no progress token (control case)', async () => {
+    // Control case for the reset mechanics: without an onprogress handler the
+    // SDK attaches no progress token, so no heartbeats are ever sent and the
+    // client's own timeout fires untouched — the pre-fix behavior for
+    // non-opting clients, preserved bit-for-bit.
+    const server = makeServer(async () => {
+      await sleep(TICK * 6);
+      return { content: [{ type: 'text', text: 'done' }] };
+    });
+    const client = await link(server);
+
+    await expect(
+      client.callTool({ name: 'slow_tool', arguments: {} }, CallToolResultSchema, {
+        timeout: TICK * 2,
+      }),
+    ).rejects.toThrow(/timed out/i);
+
+    await client.close();
+    await server.close();
+  });
+
+  it('sends no progress notifications when the client supplied no progress token', async () => {
+    const server = makeServer(async () => {
+      await sleep(TICK * 4);
+      return { content: [{ type: 'text', text: 'done' }] };
+    });
+    // No onprogress in the request options → the SDK attaches no progress
+    // token → the server must send zero progress notifications. A stray
+    // server notification would surface as a client onerror ("unknown
+    // token"), so assert both the callback silence and no errors.
+    const client = await link(server);
+    const onprogress = vi.fn();
+    const onError = vi.fn();
+    client.onerror = onError;
+    try {
+      await client.callTool({ name: 'slow_tool', arguments: {} }, CallToolResultSchema, {
+        timeout: TICK * 10,
+      });
+      expect(onprogress).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('heartbeat stopper is idempotent and inert without a token', async () => {
+    // Unit-level check of the stop-function contract: calling stop twice is
+    // safe, and a heartbeat that never started (no token) yields a no-op
+    // stopper.
+    const stopNoop = startProgressHeartbeat(fakeExtra(), {
+      method: 'tools/call',
+      params: { name: 'x', arguments: {} },
+    } as Parameters<typeof startProgressHeartbeat>[1]);
+    expect(() => stopNoop()).not.toThrow();
+    expect(() => stopNoop()).not.toThrow(); // idempotent
+
+    const server = makeServer(async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+    const client = await link(server);
+    try {
+      const result = await client.callTool(
+        { name: 'fast_tool', arguments: {} },
+        CallToolResultSchema,
+        { timeout: 1000 },
+      );
+      expect(JSON.stringify(result)).toContain('ok');
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});
+
+// Minimal RequestHandlerExtra stub for direct stopper tests — sendNotification
+// must never be reached here (throws if called).
+const fakeExtra = (): Parameters<typeof startProgressHeartbeat>[0] =>
+  ({
+    sendNotification: () => {
+      throw new Error('unexpected notification: no token means no heartbeat');
+    },
+  }) as Parameters<typeof startProgressHeartbeat>[0];


### PR DESCRIPTION
## Problem

MCP clients impose a per-request timeout on every `tools/call` — the TypeScript SDK's default is **60 seconds** (`DEFAULT_REQUEST_TIMEOUT_MSEC`). Long-running tools (`run_script` simulations, playtests) routinely exceed that, and the failure mode is nasty:

```
MCP error -32001: Request timed out
```

…while the tool **keeps executing server-side**, holding the single in-flight command slot. Agents then retry and wedge the server. Passing a larger `timeout` to the tool does not help: the cap lives in the client's transport layer, not the tool handler.

The spec provides an escape hatch: clients that set `resetTimeoutOnProgress: true` reset their per-request timer each time the server sends a `notifications/progress` notification carrying that request's `progressToken` (the SDK attaches a token only when the caller registers an `onprogress` handler — notably, e.g. opencode opts in). But a server that never sends progress notifications gains nothing from that mechanism.

## Fix

The `CallToolRequest` handler now starts a **progress heartbeat** for the lifetime of every dispatched tool call:

- Sends `notifications/progress` on the client's progress token immediately, then every **20s** (3 beats per SDK-default 60s window).
- Fires **only when the client attached a token** (caller passed `onprogress`). Clients that did not opt in see zero new traffic and completely unchanged timeout behavior — no client detection, spec-standard mechanism.
- Heartbeat errors (transport hiccup, unsupported notification) are caught and logged; they never fail the tool call itself. Worst case the client's own timeout fires, i.e. exactly the pre-fix behavior.
- Started before dispatch and stopped in a `finally` block on handler settle (success or throw). The stop function is idempotent and inert when no token was present.

Minimal diff: a 9-line wrapper in `src/index.ts` around `dispatchToolCall` plus the self-contained util.

## Tests

`tests/integration/progress-heartbeat.test.ts` — real `Server`↔`Client` over `InMemoryTransport`, injectable short (25ms) heartbeat interval:

1. **Regression (the bug)**: a tool slower than the client timeout completes successfully when the client sets `resetTimeoutOnProgress: true` + `onprogress` — previously `-32001`.
2. **Control**: a client with no progress token still times out at its own limit (pre-fix behavior preserved for non-opting clients).
3. **No-token silence**: zero progress notifications are sent (asserted via both an unregistered callback and `client.onerror` staying silent — a stray notification with an unknown token would surface as a client error).
4. **Stopper contract**: no-op stopper is safe to call twice (idempotent), and a throwing `sendNotification` stub proves no send is even attempted without a token.

## Live validation

Beyond the test suite, this branch has been validated in production conditions in an agentic game-building harness (12-session autonomous run): a **70.3-second `run_script` completed successfully** through a client using the SDK defaults + `resetTimeoutOnProgress`, where the identical workload on the previous release died at 60s with `-32001`. No client changes were required.

Full `npm run verify` green (typecheck, lint, format, tests, build).
