### PR TITLE
fix(diagnostics): surface compiler message + line in validate and run_script errors

### DIFF
--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -22,6 +22,7 @@ import {
 } from '../utils/arg-parsing.js';
 import { ok, err, type Result } from '../utils/result.js';
 import { logDebug } from '../utils/logger.js';
+import { parseScriptDiagnostics } from '../utils/output-parsing.js';
 import { randomUUID } from 'crypto';
 import {
   createNullContext,
@@ -1633,11 +1634,11 @@ export async function handleRunScript(
   const timeout = timeoutResult.value ?? 30000;
 
   try {
-    const { response: responseStr, runtimeErrors } = await runner.sendCommandWithErrors(
-      'run_script',
-      { source: script },
-      timeout,
-    );
+    const {
+      response: responseStr,
+      runtimeErrors,
+      stderrWindow,
+    } = await runner.sendCommandWithErrors('run_script', { source: script }, timeout);
 
     const parsedResult = parseBridgeJson<{
       success?: boolean;
@@ -1648,9 +1649,29 @@ export async function handleRunScript(
     const parsed = parsedResult.value;
 
     if (parsed.error) {
+      // Compilation failures (error 43 class): the bridge returns a bare
+      // "Script compilation failed (error N). Check syntax." with no location,
+      // while the actual parser diagnostic (message + line) is on the engine
+      // process stderr — captured by sendCommandWithErrors in stderrWindow
+      // (unfiltered, so the "at: <path>:<line>" lines survive).
+      // Surface it directly instead of sending the agent hunting through
+      // get_debug_output for it.
+      let compileDetail = '';
+      if (/Script compilation failed/.test(parsed.error)) {
+        const diagnostics = parseScriptDiagnostics(stderrWindow.join('\n'));
+        if (diagnostics.length > 0) {
+          const parts = diagnostics.map(
+            (d) =>
+              `${d.filePath ?? 'submitted script'}${d.line !== undefined ? `:${d.line}` : ''}: ${d.message}`,
+          );
+          compileDetail = `\nCompiler diagnostics:\n${parts.join('\n')}`;
+        }
+      }
       return err(
-        createErrorResponse(`Script execution error: ${parsed.error}`, [
-          'Check your GDScript syntax',
+        createErrorResponse(`Script execution error: ${parsed.error}${compileDetail}`, [
+          ...(compileDetail
+            ? ['Fix the reported line in the submitted script source']
+            : ['Check your GDScript syntax']),
           'Ensure the script extends RefCounted',
           'Check get_debug_output for details',
         ]),

--- a/src/tools/validate-tools.ts
+++ b/src/tools/validate-tools.ts
@@ -7,6 +7,7 @@ import { normalizeParameters } from '../utils/parameter-conversion.js';
 import { validateSubPath } from '../utils/path-validation.js';
 import { createErrorResponse, extractGdError, getErrorMessage } from '../utils/error-response.js';
 import { parseProjectArgs, optionalString } from '../utils/arg-parsing.js';
+import { parseScriptDiagnostics, type StderrDiagnostic } from '../utils/output-parsing.js';
 import { ok, err } from '../utils/result.js';
 
 export const validateToolDefinitions = [
@@ -67,103 +68,15 @@ interface ValidationError {
   message: string;
 }
 
-interface ParsedErrorEntry {
-  message: string;
-  line?: number;
-  filePath?: string;
-}
-
 /**
  * Core Godot stderr parser. Returns a flat list of error entries, each with an
  * optional line number and optional res:// file path (from the "at:" line).
  */
+type ParsedErrorEntry = StderrDiagnostic;
+
 function parseGodotErrorEntries(stderr: string): ParsedErrorEntry[] {
-  const entries: ParsedErrorEntry[] = [];
-  if (!stderr) return entries;
-
-  const lines = stderr.split('\n');
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (line === undefined) continue;
-
-    // Pattern: "SCRIPT ERROR: Parse Error: MESSAGE" or "ERROR: MESSAGE"
-    // followed by "   at: res://...:LINE" or "   at: ...:LINE"
-    const scriptErrorMatch = line.match(/SCRIPT ERROR:\s*(?:Parse Error:\s*)?(.+)/);
-    const errorMatch = !scriptErrorMatch ? line.match(/^ERROR:\s*(.+)/) : null;
-    const match = scriptErrorMatch || errorMatch;
-
-    if (match) {
-      const [, rawMessage = ''] = match;
-      const message = rawMessage.trim();
-      let lineNum: number | undefined;
-      let filePath: string | undefined;
-
-      const next = lines[i + 1];
-      if (next !== undefined) {
-        // Try res:// path first (captures file + line). Tolerates an optional
-        // "<method> (" prefix before res:// so we catch both
-        //   "   at: res://foo.gd:3"
-        // and
-        //   "   at: GDScript::reload (res://foo.gd:3)"
-        // Real Godot 4.5 stderr uses the parenthesized form.
-        const resAtMatch = next.match(/\s*at:\s*(?:[^()\n]*\()?(res:\/\/[^):"\s]+):(\d+)/);
-        if (resAtMatch) {
-          const [, path = '', lineStr = '0'] = resAtMatch;
-          filePath = path;
-          lineNum = parseInt(lineStr, 10);
-          i++;
-        } else {
-          // Fall back to loose match (line only, e.g. native code "at:" lines)
-          const looseAtMatch = next.match(/\s*at:\s*.+:(\d+)/);
-          if (looseAtMatch) {
-            lineNum = parseInt(looseAtMatch[1] ?? '0', 10);
-            i++;
-          }
-        }
-      }
-
-      // Parse-error entries reference synthetic gdscript:// URIs in their `at:` line
-      // rather than a res:// path. Peek forward up to 10 lines for the secondary
-      // "Failed to load script/resource: \"res://...\"" message that names the file,
-      // and adopt that path so batch error attribution can find it. The window is
-      // intentionally wide enough to clear a full GDScript backtrace.
-      if (!filePath && /Parse Error/i.test(line)) {
-        const lookaheadLimit = Math.min(i + 11, lines.length);
-        for (let j = i + 1; j < lookaheadLimit; j++) {
-          const lookLine = lines[j];
-          if (lookLine === undefined) continue;
-          const failMatch = lookLine.match(
-            /Failed to load (?:script|resource):?\s*"?(res:\/\/[^":\s]+)/,
-          );
-          if (failMatch) {
-            filePath = failMatch[1];
-            break;
-          }
-        }
-      }
-
-      const entry: ParsedErrorEntry = { message };
-      if (lineNum !== undefined) entry.line = lineNum;
-      if (filePath !== undefined) entry.filePath = filePath;
-      entries.push(entry);
-      continue;
-    }
-
-    // Pattern: "Parse Error: MESSAGE at line LINE"
-    const parseErrorMatch = line.match(/Parse Error:\s*(.+?)\s+at line\s+(\d+)/);
-    if (parseErrorMatch) {
-      const [, parseMsg = '', parseLine = '0'] = parseErrorMatch;
-      entries.push({
-        line: parseInt(parseLine, 10),
-        message: parseMsg.trim(),
-      });
-    }
-  }
-
-  return entries;
+  return parseScriptDiagnostics(stderr);
 }
-
 function parseGodotErrors(stderr: string): ValidationError[] {
   return parseGodotErrorEntries(stderr).map(({ message, line }) => {
     const err: ValidationError = { message };

--- a/src/tools/validate-tools.ts
+++ b/src/tools/validate-tools.ts
@@ -7,7 +7,7 @@ import { normalizeParameters } from '../utils/parameter-conversion.js';
 import { validateSubPath } from '../utils/path-validation.js';
 import { createErrorResponse, extractGdError, getErrorMessage } from '../utils/error-response.js';
 import { parseProjectArgs, optionalString } from '../utils/arg-parsing.js';
-import { parseScriptDiagnostics, type StderrDiagnostic } from '../utils/output-parsing.js';
+import { parseScriptDiagnostics } from '../utils/output-parsing.js';
 import { ok, err } from '../utils/result.js';
 
 export const validateToolDefinitions = [
@@ -68,17 +68,8 @@ interface ValidationError {
   message: string;
 }
 
-/**
- * Core Godot stderr parser. Returns a flat list of error entries, each with an
- * optional line number and optional res:// file path (from the "at:" line).
- */
-type ParsedErrorEntry = StderrDiagnostic;
-
-function parseGodotErrorEntries(stderr: string): ParsedErrorEntry[] {
-  return parseScriptDiagnostics(stderr);
-}
 function parseGodotErrors(stderr: string): ValidationError[] {
-  return parseGodotErrorEntries(stderr).map(({ message, line }) => {
+  return parseScriptDiagnostics(stderr).map(({ message, line }) => {
     const err: ValidationError = { message };
     if (line !== undefined) err.line = line;
     return err;
@@ -109,7 +100,7 @@ function writeTempGdScript(
  */
 function parseGodotErrorsByPath(stderr: string): Map<string, ValidationError[]> {
   const result = new Map<string, ValidationError[]>();
-  for (const { message, line, filePath } of parseGodotErrorEntries(stderr)) {
+  for (const { message, line, filePath } of parseScriptDiagnostics(stderr)) {
     if (filePath) {
       if (!result.has(filePath)) result.set(filePath, []);
       const err: ValidationError = { message };

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -905,13 +905,17 @@ export class GodotRunner {
     command: string,
     params: Record<string, unknown> = {},
     timeoutMs: number = 10000,
-  ): Promise<{ response: string; runtimeErrors: string[] }> {
+  ): Promise<{ response: string; runtimeErrors: string[]; stderrWindow: string[] }> {
     const marker = this.getErrorCount();
     const response = await this.sendCommandWithReconnect(command, params, timeoutMs);
     const newErrors = this.getErrorsSince(marker);
     const runtimeErrors =
       this.activeSessionMode === 'spawned' ? this.extractRuntimeErrors(newErrors) : [];
-    return { response, runtimeErrors };
+    // Unfiltered stderr window (newErrors) for callers that need the full
+    // engine output around a failure — e.g. run_script compile diagnostics,
+    // where the SCRIPT ERROR line is followed by an "at: <path>:<line>" line
+    // that extractRuntimeErrors' per-line filter drops.
+    return { response, runtimeErrors, stderrWindow: newErrors };
   }
 
   /**

--- a/src/utils/output-parsing.ts
+++ b/src/utils/output-parsing.ts
@@ -82,3 +82,108 @@ export function cleanStdout(stdout: string): string {
   }
   return cleanOutput(stdout);
 }
+
+export interface StderrDiagnostic {
+  message: string;
+  line?: number;
+  filePath?: string;
+}
+
+/**
+ * Parse Godot script-compiler diagnostics from a raw stderr stream.
+ *
+ * Both the headless `validate` path and the live-bridge `run_script` path hit
+ * the same underlying failure: GDScript compile errors are not returned by
+ * the API call that triggers them (`load()` hands back a placeholder
+ * resource; `GDScript.reload()` returns a bare error code) — the message,
+ * line number, and location are printed to stderr in Godot's canonical
+ * format:
+ *
+ *   SCRIPT ERROR: Parse Error: Identifier "x" not declared in the current scope.
+ *             at: GDScript::reload (res://scripts/foo.gd:3)
+ *
+ * This is the single shared parser for that format (Phase 1 + Phase 7 of the
+ * diagnostics roadmap). Behavior:
+ *
+ * - Recognizes `SCRIPT ERROR:` / `USER SCRIPT ERROR:` prefixes (the same
+ *   marker set GodotRunner.SCRIPT_ERROR_PATTERNS gates on) plus bare
+ *   `Parse Error: ... at line N` lines.
+ * - Extracts the file + line from the `at:` line that follows, tolerating
+ *   the `<method> (path:line)` and bare `path:line` forms. `gdscript://`
+ *   URIs (runtime-compiled sources with no res:// identity) yield no
+ *   filePath — the line number still applies to the submitted source.
+ * - Suppresses the redundant follow-on `ERROR: Failed to load script
+ *   "res://..." with error "..."` echo: it restates a SCRIPT ERROR already
+ *   captured, and its own `at:` line points into Godot's engine source
+ *   (e.g. gdscript_resource_format.cpp:46), which would surface as a bogus
+ *   line number for the user's script.
+ */
+export function parseScriptDiagnostics(stderr: string): StderrDiagnostic[] {
+  const entries: StderrDiagnostic[] = [];
+  if (!stderr) return entries;
+
+  const lines = stderr.split('\n');
+  const reportedFailures = new Set<string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+
+    // Pattern: "SCRIPT ERROR: Parse Error: MESSAGE" (or without "Parse Error:")
+    const scriptErrorMatch = line.match(
+      /(?:SCRIPT ERROR|USER SCRIPT ERROR):\s*(?:Parse Error:\s*)?(.+)/,
+    );
+    if (scriptErrorMatch) {
+      const [, rawMessage = ''] = scriptErrorMatch;
+      const message = rawMessage.trim();
+      let lineNum: number | undefined;
+      let filePath: string | undefined;
+
+      // "Failed to load script" echoes are suppressed only for the rest of
+      // this block — the primary SCRIPT ERROR above them is the diagnostic.
+      const next = lines[i + 1];
+      if (next !== undefined) {
+        // "<method> (res://path:line)" and bare "res://path:line"
+        const atMatch = next.match(
+          /\s*at:\s*(?:[^()\n]*\()?\(?((?:res:|gdscript:|file:)?\/\/[^):"\s]+|[a-z]:[^):"\s]+):(\d+)\)?/,
+        );
+        if (atMatch) {
+          const [, path = '', lineStr = '0'] = atMatch;
+          filePath = path.startsWith('res://') ? path : undefined;
+          lineNum = parseInt(lineStr, 10);
+          i++;
+        }
+      }
+
+      // De-duplicate: Godot re-emits the same parse error once per load
+      // attempt of the same script (e.g. `load()` in validate + the engine's
+      // own retry). Keep the first occurrence.
+      const key = `${filePath ?? ''}:${lineNum ?? 0}:${message}`;
+      if (reportedFailures.has(key)) continue;
+      reportedFailures.add(key);
+
+      const entry: StderrDiagnostic = { message };
+      if (lineNum !== undefined) entry.line = lineNum;
+      if (filePath !== undefined) entry.filePath = filePath;
+      entries.push(entry);
+      continue;
+    }
+
+    // Pattern: "Parse Error: MESSAGE at line LINE" (older headless format)
+    const parseErrorMatch = line.match(/Parse Error:\s*(.+?)\s+at line\s+(\d+)/);
+    if (parseErrorMatch) {
+      const [, parseMsg = '', parseLine = '0'] = parseErrorMatch;
+      const message = parseMsg.trim();
+      const key = `:${parseInt(parseLine, 10)}:${message}`;
+      if (reportedFailures.has(key)) continue;
+      reportedFailures.add(key);
+      entries.push({ line: parseInt(parseLine, 10), message });
+    }
+
+    // Suppressed: "ERROR: Failed to load script ..." echoes (restating an
+    // already-captured SCRIPT ERROR, with an engine-source at: line that
+    // would masquerade as a line number in the user's script).
+  }
+
+  return entries;
+}

--- a/src/utils/output-parsing.ts
+++ b/src/utils/output-parsing.ts
@@ -112,11 +112,12 @@ export interface StderrDiagnostic {
  *   the `<method> (path:line)` and bare `path:line` forms. `gdscript://`
  *   URIs (runtime-compiled sources with no res:// identity) yield no
  *   filePath — the line number still applies to the submitted source.
- * - Suppresses the redundant follow-on `ERROR: Failed to load script
- *   "res://..." with error "..."` echo: it restates a SCRIPT ERROR already
- *   captured, and its own `at:` line points into Godot's engine source
- *   (e.g. gdscript_resource_format.cpp:46), which would surface as a bogus
- *   line number for the user's script.
+ * - Captures bare `ERROR:` lines (non-script failures — notably scene file
+ *   parse errors carrying an inline `[Resource file res://x:N]` location),
+ *   while suppressing the redundant `Failed to load/load` echo lines whose
+ *   `at:` lines point into Godot's engine source (e.g.
+ *   gdscript_resource_format.cpp:46) and would surface as bogus line
+ *   numbers for the user's file.
  */
 export function parseScriptDiagnostics(stderr: string): StderrDiagnostic[] {
   const entries: StderrDiagnostic[] = [];
@@ -178,11 +179,49 @@ export function parseScriptDiagnostics(stderr: string): StderrDiagnostic[] {
       if (reportedFailures.has(key)) continue;
       reportedFailures.add(key);
       entries.push({ line: parseInt(parseLine, 10), message });
+      continue;
     }
 
-    // Suppressed: "ERROR: Failed to load script ..." echoes (restating an
-    // already-captured SCRIPT ERROR, with an engine-source at: line that
-    // would masquerade as a line number in the user's script).
+    // Pattern: bare "ERROR: ..." lines — non-script failures, most importantly
+    // scene/resource file parse errors emitted during scene validation:
+    //   ERROR: Parse Error: Parse error. [Resource file res://main.tscn:4]
+    // These carry no SCRIPT ERROR prefix, so the blocks above miss them.
+    // Guard rails:
+    // - "Failed to load script/resource" echoes merely restate an error
+    //   already captured (with an engine-source at: line that would
+    //   masquerade as a line number in the user's file).
+    // - "Failed loading resource:" is the same echo class for scene loads.
+    // - The at: line below a bare ERROR points into Godot's C++ engine
+    //   source (e.g. resource_format_text.cpp:293), never into the user's
+    //   file, so line/location info is taken only from the inline
+    //   [Resource file res://x:N] suffix when present.
+    const bareErrorMatch = line.match(/^ERROR:\s*(.+)/);
+    if (bareErrorMatch) {
+      const [, rawMessage = ''] = bareErrorMatch;
+      let message = rawMessage.trim();
+      if (
+        /^Failed to load (script|resource)/i.test(message) ||
+        /^Failed loading resource/i.test(message)
+      ) {
+        continue;
+      }
+      let lineNum: number | undefined;
+      let filePath: string | undefined;
+      const resFileMatch = message.match(/\[Resource file (res:\/\/[^:\]]+):(\d+)\]/);
+      if (resFileMatch) {
+        filePath = resFileMatch[1];
+        lineNum = parseInt(resFileMatch[2] ?? '0', 10);
+        message = message.replace(/\s*\[Resource file res:\/\/[^:\]]+:\d+\]/, '').trim();
+      }
+      const key = `bare:${filePath ?? ''}:${lineNum ?? 0}:${message}`;
+      if (reportedFailures.has(key)) continue;
+      reportedFailures.add(key);
+      const entry: StderrDiagnostic = { message };
+      if (lineNum !== undefined) entry.line = lineNum;
+      if (filePath !== undefined) entry.filePath = filePath;
+      entries.push(entry);
+      continue;
+    }
   }
 
   return entries;

--- a/src/utils/output-parsing.ts
+++ b/src/utils/output-parsing.ts
@@ -90,6 +90,13 @@ export interface StderrDiagnostic {
 }
 
 /**
+ * How far past a parse/compile error to scan for the `Failed to load script`
+ * echo that names the offending file. Wide enough to clear a full GDScript
+ * backtrace between the two lines.
+ */
+const LOAD_FAILURE_LOOKAHEAD_LINES = 10;
+
+/**
  * Parse Godot script-compiler diagnostics from a raw stderr stream.
  *
  * Both the headless `validate` path and the live-bridge `run_script` path hit
@@ -102,8 +109,7 @@ export interface StderrDiagnostic {
  *   SCRIPT ERROR: Parse Error: Identifier "x" not declared in the current scope.
  *             at: GDScript::reload (res://scripts/foo.gd:3)
  *
- * This is the single shared parser for that format (Phase 1 + Phase 7 of the
- * diagnostics roadmap). Behavior:
+ * This is the single shared parser for that format. Behavior:
  *
  * - Recognizes `SCRIPT ERROR:` / `USER SCRIPT ERROR:` prefixes (the same
  *   marker set GodotRunner.SCRIPT_ERROR_PATTERNS gates on) plus bare
@@ -112,6 +118,11 @@ export interface StderrDiagnostic {
  *   the `<method> (path:line)` and bare `path:line` forms. `gdscript://`
  *   URIs (runtime-compiled sources with no res:// identity) yield no
  *   filePath — the line number still applies to the submitted source.
+ * - When a parse/compile error's `at:` line names no path at all, adopts the
+ *   path (never the line) from a nearby `Failed to load script "res://..."`
+ *   echo, so batch attribution in `validate` can still place the error. A
+ *   `gdscript://` URI counts as a path, so a runtime-compiled source is never
+ *   relabelled with an unrelated file from surrounding stderr.
  * - Captures bare `ERROR:` lines (non-script failures — notably scene file
  *   parse errors carrying an inline `[Resource file res://x:N]` location),
  *   while suppressing the redundant `Failed to load/load` echo lines whose
@@ -139,6 +150,9 @@ export function parseScriptDiagnostics(stderr: string): StderrDiagnostic[] {
       const message = rawMessage.trim();
       let lineNum: number | undefined;
       let filePath: string | undefined;
+      // Whether the `at:` line named a path of any scheme. A `gdscript://`
+      // URI counts: it has no res:// identity but it is still a definite one.
+      let atNamedAPath = false;
 
       // "Failed to load script" echoes are suppressed only for the rest of
       // this block — the primary SCRIPT ERROR above them is the diagnostic.
@@ -146,13 +160,37 @@ export function parseScriptDiagnostics(stderr: string): StderrDiagnostic[] {
       if (next !== undefined) {
         // "<method> (res://path:line)" and bare "res://path:line"
         const atMatch = next.match(
-          /\s*at:\s*(?:[^()\n]*\()?\(?((?:res:|gdscript:|file:)?\/\/[^):"\s]+|[a-z]:[^):"\s]+):(\d+)\)?/,
+          /\s*at:\s*(?:[^()\n]*\()?\(?((?:res:|gdscript:|file:)?\/\/[^):"\s]+):(\d+)\)?/,
         );
         if (atMatch) {
           const [, path = '', lineStr = '0'] = atMatch;
           filePath = path.startsWith('res://') ? path : undefined;
           lineNum = parseInt(lineStr, 10);
+          atNamedAPath = true;
           i++;
+        }
+      }
+
+      // The `at:` line of a parse/compile error names a synthetic
+      // `gdscript://` URI (runtime-compiled source) or points into Godot's
+      // own C++ source, leaving the entry with no res:// identity. Batch
+      // attribution in `validate` drops filePath-less entries, so recover the
+      // path from the `Failed to load script "res://..."` echo that follows
+      // within a full GDScript backtrace. Only the path is adopted -- the
+      // echo's own `at:` line points at engine source and would surface as a
+      // bogus line number in the user's file.
+      if (!filePath && !atNamedAPath && /Parse Error|Compile Error/i.test(line)) {
+        const lookaheadLimit = Math.min(i + LOAD_FAILURE_LOOKAHEAD_LINES + 1, lines.length);
+        for (let j = i + 1; j < lookaheadLimit; j++) {
+          const lookLine = lines[j];
+          if (lookLine === undefined) continue;
+          const failMatch = lookLine.match(
+            /Failed to load (?:script|resource):?\s*"?(res:\/\/[^":\s]+)/,
+          );
+          if (failMatch) {
+            filePath = failMatch[1];
+            break;
+          }
         }
       }
 

--- a/tests/integration/run-script-diagnostics.test.ts
+++ b/tests/integration/run-script-diagnostics.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration test: run_script compile-error diagnostics (Phase 7).
+ * Integration test: run_script compile-error diagnostics.
  *
  * End-to-end regression for a real-world failure class: run_script compile
  * failures returned only "Script compilation failed (error 43). Check
@@ -15,7 +15,7 @@
  * Requires GODOT_PATH. Skipped in CI without it.
  */
 
-import { describe, beforeAll, beforeEach, afterEach, expect } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, afterAll, expect } from 'vitest';
 import { cpSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -59,6 +59,16 @@ beforeEach(() => {
 
 afterEach(async () => {
   await runner.stopProject().catch(() => undefined);
+});
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
 });
 
 describe('run_script compile-error diagnostics (live bridge)', () => {
@@ -124,14 +134,4 @@ describe('run_script compile-error diagnostics (live bridge)', () => {
     },
     60000,
   );
-});
-
-process.on('exit', () => {
-  for (const dir of tmpDirs) {
-    try {
-      rmSync(dir, { recursive: true, force: true });
-    } catch {
-      // best-effort cleanup
-    }
-  }
 });

--- a/tests/integration/run-script-diagnostics.test.ts
+++ b/tests/integration/run-script-diagnostics.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration test: run_script compile-error diagnostics (Phase 7).
+ *
+ * End-to-end regression for a real-world failure class: run_script compile
+ * failures returned only "Script compilation failed (error 43). Check
+ * syntax." — the parser's
+ * actual message + line number sat on the engine process stderr. Agents
+ * retried identical scripts and hunted get_debug_output for details.
+ *
+ * The fix: handleRunScript parses the runtimeErrors captured since the
+ * command marker and appends "Compiler diagnostics:" (message + line) to the
+ * error response. This test runs a REAL engine + bridge and asserts the
+ * enriched error comes back over the live MCP path.
+ *
+ * Requires GODOT_PATH. Skipped in CI without it.
+ */
+
+import { describe, beforeAll, beforeEach, afterEach, expect } from 'vitest';
+import { cpSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import { itGodot } from '../helpers/godot-skip.js';
+import { fixtureProjectPath } from '../helpers/fixture-paths.js';
+import { GodotRunner } from '../../src/utils/godot-runner.js';
+import { handleRunScript } from '../../src/tools/runtime-tools.js';
+// Heuristic: bridge failures we treat as "no display server" (skip-worthy)
+// rather than real failures. Mirrors runtime-smoke.test.ts.
+function isHeadlessEnvironmentError(err: string | undefined): boolean {
+  if (!err) return false;
+  const lower = err.toLowerCase();
+  return (
+    lower.includes('display') ||
+    lower.includes('no x server') ||
+    lower.includes('wayland') ||
+    lower.includes('cannot open display')
+  );
+}
+
+function makeTmpProject(): string {
+  const id = randomBytes(6).toString('hex');
+  const dst = join(tmpdir(), `godot-mcp-runscript-diag-${id}`);
+  cpSync(fixtureProjectPath, dst, { recursive: true });
+  return dst;
+}
+
+const tmpDirs: string[] = [];
+
+let runner: GodotRunner;
+
+beforeAll(async () => {
+  runner = new GodotRunner({ godotPath: process.env.GODOT_PATH });
+  await runner.detectGodotPath();
+});
+
+beforeEach(() => {
+  tmpDirs.push(makeTmpProject());
+});
+
+afterEach(async () => {
+  await runner.stopProject().catch(() => undefined);
+});
+
+describe('run_script compile-error diagnostics (live bridge)', () => {
+  itGodot(
+    'enriches error-43 compile failures with stderr compiler diagnostics',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1]!;
+      await runner.runProject(tmpProject);
+      const bridgeResult = await runner.waitForBridge(20000);
+      if (!bridgeResult.ready) {
+        if (isHeadlessEnvironmentError(bridgeResult.error)) {
+          return; // no display server — same skip semantics as runtime-smoke
+        }
+        throw new Error(`Bridge failed to initialise: ${bridgeResult.error ?? 'unknown error'}`);
+      }
+
+      // Line 3 references an undeclared identifier — compile error 43 class.
+      const badScript =
+        'extends RefCounted\n' +
+        'func execute(scene_tree: SceneTree) -> Variant:\n' +
+        '\treturn some_missing_identifier\n';
+
+      const result = await handleRunScript(runner, { script: badScript, timeout: 15000 });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      const payload = result.error as { content?: Array<{ text?: string }> };
+      const text = payload.content?.[0]?.text ?? '';
+
+      expect(text).toContain('Script compilation failed');
+      expect(text).toContain('Compiler diagnostics');
+      // The diagnostic names the offender and its line in the submitted source
+      expect(text).toContain('some_missing_identifier');
+      expect(text).toMatch(/:3\b/);
+    },
+    60000,
+  );
+
+  itGodot(
+    'a syntactically valid script still executes normally',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1]!;
+      await runner.runProject(tmpProject);
+      const bridgeResult = await runner.waitForBridge(20000);
+      if (!bridgeResult.ready) {
+        if (isHeadlessEnvironmentError(bridgeResult.error)) {
+          return;
+        }
+        throw new Error(`Bridge failed to initialise: ${bridgeResult.error ?? 'unknown error'}`);
+      }
+
+      const goodScript =
+        'extends RefCounted\n' +
+        'func execute(scene_tree: SceneTree) -> Variant:\n' +
+        '\treturn 1 + 1\n';
+
+      const result = await handleRunScript(runner, { script: goodScript, timeout: 15000 });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const text = result.value.content[0]?.text ?? '';
+      expect(text).toContain('"result":2');
+    },
+    60000,
+  );
+});
+
+process.on('exit', () => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});

--- a/tests/unit/handlers/run-script-diagnostics.test.ts
+++ b/tests/unit/handlers/run-script-diagnostics.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests: run_script compile-error diagnostics enrichment (Phase 7).
+ * Regression tests: run_script compile-error diagnostics enrichment.
  *
  * Observed in production agent workflows: run_script compile failures each
  * returned only "Script compilation failed (error 43). Check syntax." — no

--- a/tests/unit/handlers/run-script-diagnostics.test.ts
+++ b/tests/unit/handlers/run-script-diagnostics.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression tests: run_script compile-error diagnostics enrichment (Phase 7).
+ *
+ * Observed in production agent workflows: run_script compile failures each
+ * returned only "Script compilation failed (error 43). Check syntax." — no
+ * line, no message. Agents blindly retried identical scripts and repeatedly
+ * called get_debug_output hunting for details that were sitting on the
+ * engine process stderr.
+ *
+ * The fix: handleRunScript, on a compilation-failure error, parses the
+ * runtimeErrors captured by sendCommandWithErrors (which include the
+ * engine-stderr SCRIPT ERROR block) and appends "Compiler diagnostics:" with
+ * message + line to the error response.
+ *
+ * Uses a minimal fake runner — run_script's handler path needs a runtime
+ * session shape, not the executeOperation fake.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { GodotRunner } from '../../../src/utils/godot-runner.js';
+
+interface FakeRunnerOverrides {
+  response: string;
+  runtimeErrors: string[];
+  sessionMode?: 'spawned' | 'attached' | null;
+}
+
+function makeFakeRunner(o: FakeRunnerOverrides): GodotRunner {
+  const fake = {
+    activeProjectPath: '/fake/project',
+    activeSessionMode: o.sessionMode ?? 'spawned',
+    activeProcess: { hasExited: false },
+    async sendCommandWithErrors(): Promise<{
+      response: string;
+      runtimeErrors: string[];
+      stderrWindow: string[];
+    }> {
+      return {
+        response: o.response,
+        runtimeErrors: o.runtimeErrors,
+        stderrWindow: o.runtimeErrors,
+      };
+    },
+  };
+  return fake as unknown as GodotRunner;
+}
+
+// A benign script that passes the policy gate (no flagged primitives).
+const BENIGN_SCRIPT =
+  'extends RefCounted\nfunc execute(scene_tree: SceneTree) -> Variant:\n\treturn 1\n';
+
+const COMPILE_FAIL_RESPONSE = JSON.stringify({
+  error: 'Script compilation failed (error 43). Check syntax.',
+});
+
+const ERROR43_STDERR = [
+  'SCRIPT ERROR: Parse Error: Identifier "some_missing_thing" not declared in the current scope.',
+  '          at: GDScript::reload (gdscript://-9223372010447436344.gd:4)',
+  '          GDScript backtrace (most recent call first):',
+];
+
+describe('handleRunScript compile-error diagnostics (error-43 class)', () => {
+  it('enriches "Script compilation failed" errors with stderr compiler diagnostics', async () => {
+    const { handleRunScript } = await import('../../../src/tools/runtime-tools.js');
+    const fake = makeFakeRunner({
+      response: COMPILE_FAIL_RESPONSE,
+      runtimeErrors: [...ERROR43_STDERR],
+    });
+    const result = await handleRunScript(fake, { script: BENIGN_SCRIPT });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const text = JSON.stringify(result.error);
+    expect(text).toContain('Compiler diagnostics');
+    expect(text).toContain('some_missing_thing');
+    expect(text).toContain(':4');
+  });
+
+  it('still returns the bare error when stderr yields no diagnostics', async () => {
+    const { handleRunScript } = await import('../../../src/tools/runtime-tools.js');
+    const fake = makeFakeRunner({
+      response: COMPILE_FAIL_RESPONSE,
+      runtimeErrors: [],
+    });
+    const result = await handleRunScript(fake, { script: BENIGN_SCRIPT });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const text = JSON.stringify(result.error);
+    expect(text).toContain('Script compilation failed (error 43)');
+    expect(text).not.toContain('Compiler diagnostics');
+  });
+
+  it('non-compilation bridge errors are not enriched', async () => {
+    const { handleRunScript } = await import('../../../src/tools/runtime-tools.js');
+    const fake = makeFakeRunner({
+      response: JSON.stringify({ error: 'Script must define func execute' }),
+      runtimeErrors: [...ERROR43_STDERR],
+    });
+    const result = await handleRunScript(fake, { script: BENIGN_SCRIPT });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    const text = JSON.stringify(result.error);
+    expect(text).not.toContain('Compiler diagnostics');
+  });
+});

--- a/tests/unit/handlers/validate-handler.test.ts
+++ b/tests/unit/handlers/validate-handler.test.ts
@@ -137,7 +137,7 @@ describe('handleValidate', () => {
     expect(parsed.errors[0].message).toContain('Unexpected token');
   });
 
-  // --- Phase 1 regressions: autoload-aware validation + diagnostic quality ---
+  // --- Autoload-aware validation + diagnostic quality regressions ---
 
   it('reports autoload-reference compile errors with file and line (error-43 class)', async () => {
     // Real-world failure class: scripts referencing autoload singletons produce a

--- a/tests/unit/handlers/validate-handler.test.ts
+++ b/tests/unit/handlers/validate-handler.test.ts
@@ -136,6 +136,57 @@ describe('handleValidate', () => {
     expect(parsed.errors.length).toBeGreaterThan(0);
     expect(parsed.errors[0].message).toContain('Unexpected token');
   });
+
+  // --- Phase 1 regressions: autoload-aware validation + diagnostic quality ---
+
+  it('reports autoload-reference compile errors with file and line (error-43 class)', async () => {
+    // Real-world failure class: scripts referencing autoload singletons produce a
+    // "Compile Error: Identifier not found" on stderr that the handler must
+    // overlay (message + line) instead of reporting a bare invalid.
+    const fake = createFakeRunner({
+      stdout: JSON.stringify({ valid: true, errors: [] }),
+      stderr: [
+        'SCRIPT ERROR: Compile Error: Identifier not found: GameState',
+        '          at: GDScript::reload (res://scripts/uses_autoload.gd:3)',
+        'ERROR: Failed to load script "res://scripts/uses_autoload.gd" with error "Compilation failed".',
+        '   at: load (modules/gdscript/gdscript_resource_format.cpp:46)',
+      ].join('\n'),
+    });
+    const result = await handleValidate(fake.asRunner, {
+      projectPath: fixtureProjectPath,
+      source: 'func probe() -> int:\n\treturn GameState.score\n',
+    });
+    expect(hasError(result)).toBe(false);
+    const parsed = JSON.parse(unwrap(result).content[0].text);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors[0].message).toContain('GameState');
+    expect(parsed.errors[0].line).toBe(3);
+  });
+
+  it('does not surface engine-source line numbers from "Failed to load" echoes', async () => {
+    // The engine echo "ERROR: Failed to load script ..." carries an at: line
+    // pointing into Godot's C++ source (e.g. gdscript_resource_format.cpp:46).
+    // Before the shared-parser dedup, that surfaced as a bogus error entry
+    // with a line number belonging to nobody's script.
+    const fake = createFakeRunner({
+      stdout: JSON.stringify({ valid: true, errors: [] }),
+      stderr: [
+        'SCRIPT ERROR: Parse Error: Identifier "x" not declared in the current scope.',
+        '          at: GDScript::reload (res://scripts/a.gd:7)',
+        'ERROR: Failed to load script "res://scripts/a.gd" with error "Parse error".',
+        '   at: load (modules/gdscript/gdscript_resource_format.cpp:46)',
+      ].join('\n'),
+    });
+    const result = await handleValidate(fake.asRunner, {
+      projectPath: fixtureProjectPath,
+      source: 'var x',
+    });
+    const parsed = JSON.parse(unwrap(result).content[0].text);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors[0].line).toBe(7);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/parse-script-diagnostics.test.ts
+++ b/tests/unit/parse-script-diagnostics.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for parseScriptDiagnostics — the shared Godot stderr compiler-
  * diagnostic parser.
  *
- * Context (Phase 1 + Phase 7 of the diagnostics roadmap): GDScript compile
+ * Context: GDScript compile
  * failures don't travel through the API call that triggers them — `load()`
  * returns a placeholder resource, `GDScript.reload()` returns a bare error
  * code (43) — the message and line live on stderr. Two consumers depend on
@@ -81,6 +81,52 @@ describe('parseScriptDiagnostics', () => {
         message: 'Identifier "some_missing_thing" not declared in the current scope.',
         line: 4,
       },
+    ]);
+  });
+
+  it('recovers filePath from the "Failed to load script" echo when at: names no res:// path', () => {
+    // The at: line points into Godot's C++ source, so the entry would carry no
+    // res:// identity -- and parseGodotErrorsByPath drops filePath-less entries,
+    // silently reporting the file valid in batch validate.
+    const stderr = [
+      'SCRIPT ERROR: Parse Error: Identifier "x" not declared in the current scope.',
+      '   at: GDScript::reload (modules/gdscript/gdscript.cpp:2907)',
+      '   GDScript backtrace (most recent call first):',
+      '       [0] _validate_single (res://.mcp/ops.gd:1126)',
+      'ERROR: Failed to load script "res://scripts/late.gd" with error "Parse error".',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      {
+        message: 'Identifier "x" not declared in the current scope.',
+        filePath: 'res://scripts/late.gd',
+      },
+    ]);
+  });
+
+  it('never adopts a line number from the "Failed to load script" echo', () => {
+    const stderr = [
+      'SCRIPT ERROR: Compile Error: Identifier not found: GameState',
+      '   at: GDScript::reload (modules/gdscript/gdscript.cpp:2907)',
+      'ERROR: Failed to load script "res://scripts/a.gd" with error "Compilation failed".',
+      '   at: load (modules/gdscript/gdscript_resource_format.cpp:46)',
+    ].join('\n');
+    const result = parseScriptDiagnostics(stderr);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.filePath).toBe('res://scripts/a.gd');
+    expect(result[0]?.line).toBeUndefined();
+  });
+
+  it('does not relabel a gdscript:// source with an unrelated nearby res:// path', () => {
+    // The at: line already gives the entry a definite identity (the submitted
+    // source), so the load-failure echo below must not overwrite it -- that
+    // would pair a real file path with the submitted source's line number.
+    const stderr = [
+      'SCRIPT ERROR: Parse Error: Identifier "x" not declared in the current scope.',
+      '   at: GDScript::reload (gdscript://-9223372010447436344.gd:4)',
+      'ERROR: Failed to load script "res://scripts/unrelated.gd" with error "Parse error".',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      { message: 'Identifier "x" not declared in the current scope.', line: 4 },
     ]);
   });
 

--- a/tests/unit/parse-script-diagnostics.test.ts
+++ b/tests/unit/parse-script-diagnostics.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for parseScriptDiagnostics — the shared Godot stderr compiler-
+ * diagnostic parser.
+ *
+ * Context (Phase 1 + Phase 7 of the diagnostics roadmap): GDScript compile
+ * failures don't travel through the API call that triggers them — `load()`
+ * returns a placeholder resource, `GDScript.reload()` returns a bare error
+ * code (43) — the message and line live on stderr. Two consumers depend on
+ * this parser:
+ *
+ *   - `validate` (headless): overlays stderr diagnostics onto the tool's
+ *     valid/errors result (replaces the former inline parser).
+ *   - `run_script` (live bridge): enriches "Script compilation failed
+ *     (error 43). Check syntax." errors with message + line instead of
+ *     sending the agent to hunt through get_debug_output.
+ *
+ * The fixture stderr strings below are verbatim captures from Godot 4.x runs
+ * (macOS), including the error-43 compile-failure class.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseScriptDiagnostics } from '../../src/utils/output-parsing.js';
+
+describe('parseScriptDiagnostics', () => {
+  it('returns [] for empty stderr', () => {
+    expect(parseScriptDiagnostics('')).toEqual([]);
+  });
+
+  it('parses a genuine parse error with file and line', () => {
+    const stderr = [
+      'Godot Engine v4.7.2.stable.official.ed1daf0bf - https://godotengine.org',
+      'SCRIPT ERROR: Parse Error: Identifier "missing_var" not declared in the current scope.',
+      '          at: GDScript::reload (res://scripts/broken.gd:3)',
+      '          GDScript backtrace (most recent call first):',
+      '              [0] _validate_single (res://ops.gd:1068)',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      {
+        message: 'Identifier "missing_var" not declared in the current scope.',
+        line: 3,
+        filePath: 'res://scripts/broken.gd',
+      },
+    ]);
+  });
+
+  it('parses an autoload-reference compile error (error-43 class)', () => {
+    const stderr = [
+      'SCRIPT ERROR: Compile Error: Identifier not found: GameState',
+      '          at: GDScript::reload (res://scripts/uses_autoload.gd:3)',
+      'ERROR: Failed to load script "res://scripts/uses_autoload.gd" with error "Compilation failed".',
+      '   at: load (modules/gdscript/gdscript_resource_format.cpp:46)',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      {
+        message: 'Compile Error: Identifier not found: GameState',
+        line: 3,
+        filePath: 'res://scripts/uses_autoload.gd',
+      },
+    ]);
+  });
+
+  it('suppresses the "Failed to load script" echo and its engine-source line number', () => {
+    const stderr = [
+      'SCRIPT ERROR: Parse Error: Identifier "x" not declared in the current scope.',
+      '          at: GDScript::reload (res://scripts/a.gd:7)',
+      'ERROR: Failed to load script "res://scripts/a.gd" with error "Parse error".',
+      '   at: load (modules/gdscript/gdscript_resource_format.cpp:46)',
+    ].join('\n');
+    const result = parseScriptDiagnostics(stderr);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.line).toBe(7);
+  });
+
+  it('handles runtime-compiled gdscript:// URIs — line but no filePath', () => {
+    const stderr = [
+      'SCRIPT ERROR: Parse Error: Identifier "some_missing_thing" not declared in the current scope.',
+      '          at: GDScript::reload (gdscript://-9223372010447436344.gd:4)',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      {
+        message: 'Identifier "some_missing_thing" not declared in the current scope.',
+        line: 4,
+      },
+    ]);
+  });
+
+  it('parses USER SCRIPT ERROR markers', () => {
+    const stderr = [
+      'USER SCRIPT ERROR: something exploded',
+      '          at: _ready (res://scripts/main.gd:12)',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      { message: 'something exploded', line: 12, filePath: 'res://scripts/main.gd' },
+    ]);
+  });
+
+  it('parses legacy "Parse Error: ... at line N" format', () => {
+    const stderr = 'Parse Error: Unterminated string at line 42';
+    expect(parseScriptDiagnostics(stderr)).toEqual([{ message: 'Unterminated string', line: 42 }]);
+  });
+
+  it('de-duplicates identical re-emitted errors', () => {
+    const block = [
+      'SCRIPT ERROR: Parse Error: Identifier "x" not declared in the current scope.',
+      '          at: GDScript::reload (res://scripts/a.gd:3)',
+    ].join('\n');
+    expect(parseScriptDiagnostics(`${block}\n${block}`)).toHaveLength(1);
+  });
+
+  it('ignores INFO lines and unrelated errors', () => {
+    const stderr = [
+      '[INFO] Operation: validate_resource',
+      '[INFO] Executing operation: validate_resource',
+      'Godot Engine v4.7.2 - https://godotengine.org',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([]);
+  });
+});

--- a/tests/unit/parse-script-diagnostics.test.ts
+++ b/tests/unit/parse-script-diagnostics.test.ts
@@ -115,4 +115,41 @@ describe('parseScriptDiagnostics', () => {
     ].join('\n');
     expect(parseScriptDiagnostics(stderr)).toEqual([]);
   });
+
+  it('captures bare ERROR scene-parse lines with their [Resource file] location', () => {
+    // Observed on Godot 4.7.2 validating a broken .tscn - no SCRIPT ERROR
+    // prefix; the user-file location rides inline in brackets.
+    const stderr = [
+      'ERROR: Parse Error: Parse error. [Resource file res://main.tscn:4]',
+      '   at: _parse_node_tag (scene/resources/resource_format_text.cpp:293)',
+      'ERROR: Failed loading resource: res://main.tscn.',
+      '   at: _load (core/io/resource_loader.cpp:317)',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      {
+        message: 'Parse Error: Parse error.',
+        line: 4,
+        filePath: 'res://main.tscn',
+      },
+    ]);
+  });
+
+  it('captures other bare ERROR lines without inventing a location', () => {
+    const stderr = 'ERROR: Unable to open file: res://missing.png';
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      { message: 'Unable to open file: res://missing.png' },
+    ]);
+  });
+
+  it('suppresses the bare-ERROR "Failed to load script" echo variant', () => {
+    const stderr = [
+      'SCRIPT ERROR: Parse Error: Unterminated string.',
+      '   at: GDScript::reload (res://scripts/a.gd:7)',
+      'ERROR: Failed to load script "res://scripts/a.gd" with error "Parse error".',
+      '   at: load (modules/gdscript/gdscript.cpp:285)',
+    ].join('\n');
+    expect(parseScriptDiagnostics(stderr)).toEqual([
+      { message: 'Unterminated string.', line: 7, filePath: 'res://scripts/a.gd' },
+    ]);
+  });
 });


### PR DESCRIPTION
## Problem

GDScript compile failures don't travel through the API that triggers them: `load()` returns a placeholder resource and `GDScript.reload()` returns a bare error code (43), while the actual parser diagnostic (message + line) goes to stderr. Both tools discard it:

- `run_script` returns only "Script compilation failed (error 43). Check syntax."
- `validate` echoes an engine-source line number (e.g. `gdscript_resource_format_text.cpp:46`) as if it belonged to the user's script

## Changes

- New shared `parseScriptDiagnostics()` in `utils/output-parsing.ts` (SCRIPT ERROR / Parse Error / bare ERROR formats, `at:` location extraction, engine-echo suppression, dedup, `gdscript://` handling)
- `validate` (single + batch) uses the shared parser; also captures bare-`ERROR:` scene-parse diagnostics with inline `[Resource file res://x:N]` locations, which were previously lost entirely
- `run_script` appends "Compiler diagnostics:" (`file:line: message`) parsed from the stderr window on compile failures
- `sendCommandWithErrors` additionally returns the unfiltered stderr window

## Tests

Parser unit tests, handler regression tests, and a live-bridge integration test for the error-43 class. All existing tests pass.