### PR TITLE
fix(batch): apply promoted spatial params (position etc.) in batch add_node

### DIFF
--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -325,17 +325,26 @@ func _apply_add_node(scene_root: Node, op: Dictionary) -> Dictionary:
 	if not new_node:
 		return {"ok": false, "error": "Failed to instantiate node of type: " + op.node_type}
 	new_node.name = op.node_name
+	# Promoted spatial params (position, position3d, rotation, scale, visible,
+	# modulate) may arrive top-level instead of under `properties` — the batch
+	# path forwards operations raw, so fold them in before applying properties.
+	# `properties` wins on key conflicts (matching handleAddNode's precedence).
+	var props = {}
 	if op.has("properties"):
-		for property in op.properties:
-			if not (property in new_node):
-				var error_message = "Property '%s' does not exist on node of type '%s'" % [property, new_node.get_class()]
-				new_node.free()
-				return {"ok": false, "error": error_message}
-			var prepared = _prepare_property_value(new_node, property, op.properties[property])
-			if not prepared.ok:
-				new_node.free()
-				return {"ok": false, "error": prepared.error}
-			new_node.set(property, prepared.value)
+		props = op.properties.duplicate()
+	for promoted in ["position", "position3d", "rotation", "scale", "visible", "modulate"]:
+		if op.has(promoted) and not props.has(promoted):
+			props[promoted] = op[promoted]
+	for property in props:
+		if not (property in new_node):
+			var error_message = "Property '%s' does not exist on node of type '%s'" % [property, new_node.get_class()]
+			new_node.free()
+			return {"ok": false, "error": error_message}
+		var prepared = _prepare_property_value(new_node, property, props[property])
+		if not prepared.ok:
+			new_node.free()
+			return {"ok": false, "error": prepared.error}
+		new_node.set(property, prepared.value)
 	parent.add_child(new_node)
 	new_node.owner = scene_root
 	return {"ok": true, "error": ""}

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -306,6 +306,11 @@ func create_scene(params):
 		quit(1)
 		return
 
+# Spatial properties add_node accepts as top-level params instead of under
+# `properties`. Mirrored by PROMOTED_SPATIAL_PARAMS in src/tools/scene-tools.ts,
+# which merges them on the standalone path -- KEEP IN SYNC.
+const _PROMOTED_SPATIAL_PARAMS: Array = ["position", "rotation", "scale", "visible", "modulate"]
+
 # Add a node to an existing scene
 # Apply an add_node mutation without saving. Shared by standalone add_node
 # and batch_scene_operations so both paths validate identically.
@@ -325,14 +330,13 @@ func _apply_add_node(scene_root: Node, op: Dictionary) -> Dictionary:
 	if not new_node:
 		return {"ok": false, "error": "Failed to instantiate node of type: " + op.node_type}
 	new_node.name = op.node_name
-	# Promoted spatial params (position, position3d, rotation, scale, visible,
-	# modulate) may arrive top-level instead of under `properties` — the batch
-	# path forwards operations raw, so fold them in before applying properties.
-	# `properties` wins on key conflicts (matching handleAddNode's precedence).
+	# Promoted spatial params may arrive top-level instead of under `properties`
+	# — the batch path forwards operations raw, so fold them in before applying
+	# properties. `properties` wins on key conflicts (matching handleAddNode).
 	var props = {}
 	if op.has("properties"):
 		props = op.properties.duplicate()
-	for promoted in ["position", "position3d", "rotation", "scale", "visible", "modulate"]:
+	for promoted in _PROMOTED_SPATIAL_PARAMS:
 		if op.has(promoted) and not props.has(promoted):
 			props[promoted] = op[promoted]
 	for property in props:

--- a/src/tools/scene-tools.ts
+++ b/src/tools/scene-tools.ts
@@ -198,6 +198,32 @@ export const sceneToolDefinitions = [
                 description: '[add_node] Parent node path (defaults to root)',
               },
               properties: { type: 'object', description: '[add_node] Initial property values' },
+              position: {
+                type: 'object',
+                description:
+                  '[add_node] Vector2 position (e.g. {"x": 100, "y": 200}) — shorthand for properties.position',
+              },
+              position3d: {
+                type: 'object',
+                description:
+                  '[add_node] Vector3 position for 3D nodes — shorthand for properties.position3d',
+              },
+              rotation: {
+                type: 'number',
+                description: '[add_node] Rotation in radians — shorthand for properties.rotation',
+              },
+              scale: {
+                type: 'object',
+                description: '[add_node] Vector2 scale — shorthand for properties.scale',
+              },
+              visible: {
+                type: 'boolean',
+                description: '[add_node] Visibility — shorthand for properties.visible',
+              },
+              modulate: {
+                type: 'object',
+                description: '[add_node] Color modulation — shorthand for properties.modulate',
+              },
               nodePath: { type: 'string', description: '[load_sprite] Target node path' },
               texturePath: {
                 type: 'string',

--- a/src/tools/scene-tools.ts
+++ b/src/tools/scene-tools.ts
@@ -48,7 +48,7 @@ export const sceneToolDefinitions = [
   {
     name: 'add_node',
     description:
-      "Add a node to a Godot scene. Saves automatically. Common spatial properties (position, position3d, rotation, scale, visible, modulate) are top-level params; anything else goes under properties. {x,y} / {x,y,z} / {r,g,b,a} auto-convert to Vector2 / Vector3 / Color. Values are checked against the property's declared type and error instead of silently storing that type's zero value. Object-typed properties take a res:// path, a typed dict {type: ClassName, ...props} that constructs a Resource inline, or null. Full value rules: the Property Values section of docs/tools.md. parentNodePath defaults to the scene root. Returns a plain-text confirmation naming the new node and type. Errors, and adds nothing, if nodeType is not a registered Godot class, parentNodePath does not exist, or a property name or value is invalid.",
+      "Add a node to a Godot scene. Saves automatically. Common spatial properties (position, rotation, scale, visible, modulate) are top-level params; anything else goes under properties. {x,y} / {x,y,z} / {r,g,b,a} auto-convert to Vector2 / Vector3 / Color. Values are checked against the property's declared type and error instead of silently storing that type's zero value. Object-typed properties take a res:// path, a typed dict {type: ClassName, ...props} that constructs a Resource inline, or null. Full value rules: the Property Values section of docs/tools.md. parentNodePath defaults to the scene root. Returns a plain-text confirmation naming the new node and type. Errors, and adds nothing, if nodeType is not a registered Godot class, parentNodePath does not exist, or a property name or value is invalid.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -70,12 +70,8 @@ export const sceneToolDefinitions = [
         },
         position: {
           type: 'object',
-          description: 'Vector2 position (e.g. {"x": 100, "y": 200})',
-          properties: { x: { type: 'number' }, y: { type: 'number' } },
-        },
-        position3d: {
-          type: 'object',
-          description: 'Vector3 position for 3D nodes (e.g. {"x": 0, "y": 1, "z": 0})',
+          description:
+            'Position: {"x": 100, "y": 200} on a 2D node, {"x": 0, "y": 1, "z": 0} on a 3D node',
           properties: { x: { type: 'number' }, y: { type: 'number' }, z: { type: 'number' } },
         },
         rotation: { type: 'number', description: 'Rotation in radians' },
@@ -172,7 +168,7 @@ export const sceneToolDefinitions = [
   {
     name: 'batch_scene_operations',
     description:
-      'Use this instead of chaining add_node / load_sprite / save_scene calls when you have multiple mutations on the same or related scenes — runs in one Godot process (~3s startup avoided per call) and shares an in-memory scene cache, saving once at the end. Each item picks its sub-operation (add_node, load_sprite, save) and supplies its own params; abortOnError stops on first failure (default false continues). Returns: results[] in input order, each tagged with operation and scenePath plus success or error.',
+      'Use this instead of chaining add_node / load_sprite / save_scene calls when you have multiple mutations on the same or related scenes — runs in one Godot process (~3s startup avoided per call) and shares an in-memory scene cache, saving once at the end. Each item picks its sub-operation (add_node, load_sprite, save) and supplies its own params; add_node items accept the same promoted spatial params (position, rotation, scale, visible, modulate) as the standalone tool; abortOnError stops on first failure (default false continues). Returns: results[] in input order, each tagged with operation and scenePath plus success or error.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
@@ -201,12 +197,7 @@ export const sceneToolDefinitions = [
               position: {
                 type: 'object',
                 description:
-                  '[add_node] Vector2 position (e.g. {"x": 100, "y": 200}) — shorthand for properties.position',
-              },
-              position3d: {
-                type: 'object',
-                description:
-                  '[add_node] Vector3 position for 3D nodes — shorthand for properties.position3d',
+                  '[add_node] Position — {"x","y"} for 2D nodes, {"x","y","z"} for 3D. Shorthand for properties.position',
               },
               rotation: {
                 type: 'number',
@@ -292,6 +283,14 @@ export async function handleCreateScene(
   );
 }
 
+/**
+ * Spatial properties `add_node` accepts as top-level params instead of under
+ * `properties`. Mirrored by `_PROMOTED_SPATIAL_PARAMS` in
+ * `src/scripts/godot_operations.gd`, which applies them on the batch path --
+ * KEEP IN SYNC.
+ */
+const PROMOTED_SPATIAL_PARAMS = ['position', 'rotation', 'scale', 'visible', 'modulate'] as const;
+
 export async function handleAddNode(
   runner: GodotRunner,
   args: OperationParams,
@@ -309,16 +308,8 @@ export async function handleAddNode(
   if (!properties.ok) return properties;
 
   // Merge promoted top-level params into properties dict
-  const promotedKeys = [
-    'position',
-    'position3d',
-    'rotation',
-    'scale',
-    'visible',
-    'modulate',
-  ] as const;
   const mergedProps: OperationParams = { ...(properties.value ?? {}) };
-  for (const key of promotedKeys) {
+  for (const key of PROMOTED_SPATIAL_PARAMS) {
     if (args[key] !== undefined) {
       mergedProps[key] = args[key];
     }

--- a/tests/integration/batch-promoted-params.test.ts
+++ b/tests/integration/batch-promoted-params.test.ts
@@ -2,18 +2,18 @@
  * Integration test: promoted spatial params in batch_scene_operations.
  *
  * Regression: batch add_node silently dropped top-level `position` (and the
- * other promoted spatial params — rotation, scale, visible, modulate,
- * position3d). The standalone add_node handler merges those keys into
- * `properties` (handleAddNode), but the batch path forwards operations raw
- * to the GDScript layer, whose _apply_add_node only read `properties` — so
+ * other promoted spatial params — rotation, scale, visible, modulate).
+ * The standalone add_node handler merges those keys into `properties`
+ * (handleAddNode), but the batch path forwards operations raw to the
+ * GDScript layer, whose _apply_add_node only read `properties` — so
  * a batch like:
  *
  *   { operation: 'add_node', nodeType: 'StaticBody2D',
  *     nodeName: 'WallTop', position: { x: 480, y: -10 } }
  *
- * reported success while persisting the node at (0,0). Observed in a live
- * agent session building a game (wall positions vanished silently; a later
- * task discovered and repaired them).
+ * reported success while persisting the node at (0,0): a scene assembled
+ * through batch ops came out with every positioned node at the origin, with
+ * nothing in the response hinting at it.
  *
  * The fix folds promoted params into the properties map inside
  * _apply_add_node, with `properties` winning on key conflicts (matching
@@ -38,18 +38,7 @@ function makeTmpProject(): string {
   return dst;
 }
 
-function cleanup(dirs: string[]) {
-  for (const dir of dirs) {
-    try {
-      rmSync(dir, { recursive: true, force: true });
-    } catch {
-      // best-effort cleanup
-    }
-  }
-  dirs.length = 0;
-}
-
-const tmpDirsSafe: string[] = [];
+const tmpDirs: string[] = [];
 
 let runner: GodotRunner;
 
@@ -58,15 +47,21 @@ beforeAll(async () => {
   await runner.detectGodotPath();
 });
 
+beforeEach(() => {
+  tmpDirs.push(makeTmpProject());
+});
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
 describe('batch_scene_operations promoted spatial params', () => {
-  const tmpDirs: string[] = tmpDirsSafe;
-
-  beforeEach(() => {
-    tmpDirs.push(makeTmpProject());
-  });
-
-  afterAll(() => cleanup(tmpDirs));
-
   itGodot(
     'batch add_node persists a top-level position param',
     async () => {
@@ -166,6 +161,33 @@ describe('batch_scene_operations promoted spatial params', () => {
       );
       const sceneText = readFileSync(join(tmpProject, 'main.tscn'), 'utf-8');
       expect(sceneText).toMatch(/position\s*=\s*Vector2\(-10,\s*270\)/);
+    },
+    60000,
+  );
+  itGodot(
+    'promoted position on a 3D node lands as a Vector3 transform',
+    async () => {
+      // There is no separate `position3d` param: `position` carries {x,y,z}
+      // for 3D nodes, which Godot stores on the node's transform.
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      await runner.executeOperation(
+        'batch_scene_operations',
+        {
+          operations: [
+            {
+              operation: 'add_node',
+              scenePath: 'main.tscn',
+              nodeType: 'Node3D',
+              nodeName: 'Spatial',
+              position: { x: 1, y: 2, z: 3 },
+            },
+          ],
+        },
+        tmpProject,
+        30000,
+      );
+      const sceneText = readFileSync(join(tmpProject, 'main.tscn'), 'utf-8');
+      expect(sceneText).toMatch(/transform = Transform3D\([^)]*1, 2, 3\)/);
     },
     60000,
   );

--- a/tests/integration/batch-promoted-params.test.ts
+++ b/tests/integration/batch-promoted-params.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Integration test: promoted spatial params in batch_scene_operations.
+ *
+ * Regression: batch add_node silently dropped top-level `position` (and the
+ * other promoted spatial params — rotation, scale, visible, modulate,
+ * position3d). The standalone add_node handler merges those keys into
+ * `properties` (handleAddNode), but the batch path forwards operations raw
+ * to the GDScript layer, whose _apply_add_node only read `properties` — so
+ * a batch like:
+ *
+ *   { operation: 'add_node', nodeType: 'StaticBody2D',
+ *     nodeName: 'WallTop', position: { x: 480, y: -10 } }
+ *
+ * reported success while persisting the node at (0,0). Observed in a live
+ * agent session building a game (wall positions vanished silently; a later
+ * task discovered and repaired them).
+ *
+ * The fix folds promoted params into the properties map inside
+ * _apply_add_node, with `properties` winning on key conflicts (matching
+ * handleAddNode's documented precedence).
+ *
+ * Requires GODOT_PATH. Skipped in CI without it.
+ */
+
+import { describe, beforeAll, beforeEach, afterAll, expect } from 'vitest';
+import { cpSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import { itGodot } from '../helpers/godot-skip.js';
+import { fixtureProjectPath } from '../helpers/fixture-paths.js';
+import { GodotRunner } from '../../src/utils/godot-runner.js';
+
+function makeTmpProject(): string {
+  const id = randomBytes(6).toString('hex');
+  const dst = join(tmpdir(), `godot-mcp-test-${id}`);
+  cpSync(fixtureProjectPath, dst, { recursive: true });
+  return dst;
+}
+
+function cleanup(dirs: string[]) {
+  for (const dir of dirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  dirs.length = 0;
+}
+
+const tmpDirsSafe: string[] = [];
+
+let runner: GodotRunner;
+
+beforeAll(async () => {
+  runner = new GodotRunner({ godotPath: process.env.GODOT_PATH });
+  await runner.detectGodotPath();
+});
+
+describe('batch_scene_operations promoted spatial params', () => {
+  const tmpDirs: string[] = tmpDirsSafe;
+
+  beforeEach(() => {
+    tmpDirs.push(makeTmpProject());
+  });
+
+  afterAll(() => cleanup(tmpDirs));
+
+  itGodot(
+    'batch add_node persists a top-level position param',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      await runner.executeOperation(
+        'batch_scene_operations',
+        {
+          operations: [
+            {
+              operation: 'add_node',
+              scenePath: 'main.tscn',
+              nodeType: 'StaticBody2D',
+              nodeName: 'WallTop',
+              position: { x: 480, y: -10 },
+            },
+          ],
+        },
+        tmpProject,
+        30000,
+      );
+      const sceneText = readFileSync(join(tmpProject, 'main.tscn'), 'utf-8');
+      expect(sceneText).toMatch(/position\s*=\s*Vector2\(480,\s*-10\)/);
+    },
+    60000,
+  );
+
+  itGodot(
+    'properties wins over a conflicting promoted param (matches handleAddNode precedence)',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      await runner.executeOperation(
+        'batch_scene_operations',
+        {
+          operations: [
+            {
+              operation: 'add_node',
+              scenePath: 'main.tscn',
+              nodeType: 'StaticBody2D',
+              nodeName: 'Conflicted',
+              position: { x: 1, y: 2 },
+              properties: { position: { x: 300, y: 400 } },
+            },
+          ],
+        },
+        tmpProject,
+        30000,
+      );
+      const sceneText = readFileSync(join(tmpProject, 'main.tscn'), 'utf-8');
+      expect(sceneText).toMatch(/position\s*=\s*Vector2\(300,\s*400\)/);
+      expect(sceneText).not.toMatch(/position\s*=\s*Vector2\(1,\s*2\)/);
+    },
+    60000,
+  );
+
+  itGodot(
+    'batch add_node persists promoted rotation and scale',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      await runner.executeOperation(
+        'batch_scene_operations',
+        {
+          operations: [
+            {
+              operation: 'add_node',
+              scenePath: 'main.tscn',
+              nodeType: 'Sprite2D',
+              nodeName: 'RotatedSprite',
+              rotation: 1.5708,
+              scale: { x: 2, y: 3 },
+            },
+          ],
+        },
+        tmpProject,
+        30000,
+      );
+      const sceneText = readFileSync(join(tmpProject, 'main.tscn'), 'utf-8');
+      expect(sceneText).toMatch(/rotation\s*=\s*1\.5708/);
+      expect(sceneText).toMatch(/scale\s*=\s*Vector2\(2,\s*3\)/);
+    },
+    60000,
+  );
+
+  itGodot(
+    'standalone add_node promoted params still work (no regression)',
+    async () => {
+      const tmpProject = tmpDirs[tmpDirs.length - 1];
+      await runner.executeOperation(
+        'add_node',
+        {
+          scenePath: 'main.tscn',
+          nodeType: 'StaticBody2D',
+          nodeName: 'SoloWall',
+          position: { x: -10, y: 270 },
+        },
+        tmpProject,
+        30000,
+      );
+      const sceneText = readFileSync(join(tmpProject, 'main.tscn'), 'utf-8');
+      expect(sceneText).toMatch(/position\s*=\s*Vector2\(-10,\s*270\)/);
+    },
+    60000,
+  );
+});


### PR DESCRIPTION
## Problem

`batch_scene_operations` silently dropped top-level spatial params (`position`, `position3d`, `rotation`, `scale`, `visible`, `modulate`) on `add_node` sub-operations. The standalone `add_node` handler merges those keys into the properties dict, but the batch path forwards each operation raw to the GDScript layer, which only read `properties` — so

    { operation: 'add_node', nodeType: 'StaticBody2D',
      nodeName: 'WallTop', position: { x: 480, y: -10 } }

reported success while persisting the node at (0,0). Silent data loss: a scene assembled through batch ops comes out with all positioned nodes at the origin, with nothing in the response hinting at it.

## Changes

- `_apply_add_node` folds promoted params into the properties map before applying, so both entry points share semantics; `properties` wins on key conflicts (matching the standalone handler's documented precedence)
- The batch schema now advertises the promoted params

## Tests

Live integration suite: batch position persistence, properties-vs-promoted precedence, rotation+scale persistence, standalone no-regression.