### PR TITLE
feat(profiler): profile a running project through Godot's remote debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A lightweight [MCP](https://modelcontextprotocol.io/) server that pairs comprehe
 <br>
 
 - **Headless editing** — scenes, nodes, scripts, signals, validation, no editor window
-- **Runtime control** — screenshots, input simulation, UI discovery, and live GDScript against the running game
+- **Runtime control** — screenshots, input simulation, UI discovery, live GDScript, and function profiling against the running game
 - **Zero footprint** — no Godot addon, no project commits, auto-cleanup on shutdown
 
 **No addon required.** Most Godot MCP servers that offer runtime support ship as a Godot addon, something you install into your project, commit to version control, and manage as a dependency. Use npx and there's no install or setup needed.
@@ -51,6 +51,7 @@ Think of it as [Playwright MCP](https://github.com/microsoft/playwright-mcp), bu
 - **Input simulation:** Batched sequences of key presses, mouse clicks, mouse motion, UI element clicks by name or path, Godot action events, and timed waits
 - **UI discovery:** Walk the live scene tree and collect every visible Control node with its position, type, text content, and disabled state
 - **Live script execution:** Compile and run arbitrary GDScript with full SceneTree access while the game is running
+- **Function profiling:** With `profiling: true` at launch, capture Godot's own profiler and rank the most expensive GDScript functions by own or inclusive time, with source locations and per-frame averages
 
 **Background mode.** Pass `background: true` to `run_project` and the Godot window moves off-screen (positioned at `(-9999, -9999)`) with physical input blocked: borderless, unfocusable, mouse-passthrough. Programmatic input, screenshots, and all runtime tools work exactly the same. Useful for automated agent-driven testing where the window shouldn't be visible or interactive.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@ src/
 │   ├── autoload-tools.ts   # Autoload management (list/add/remove/update_autoload)
 │   ├── scene-tools.ts      # Scene creation, node addition, sprite loading, batch ops
 │   ├── node-tools.ts       # Node properties, scripts, tree, duplication, signals
+│   ├── profiler-tools.ts   # Function profiling (profile_project, start_profiler, stop_profiler)
 │   └── validate-tools.ts   # GDScript and scene validation
 ├── scripts/
 │   ├── godot_operations.gd # Headless GDScript operations
@@ -27,6 +28,8 @@ src/
     ├── headless-op.ts           # executeSceneOp wrapper for headless-op handlers
     ├── bridge-manager.ts        # McpBridge artifact lifecycle (inject, cleanup, repair)
     ├── bridge-protocol.ts       # TCP framing (length-prefixed frames, port resolution)
+    ├── profiler.ts              # Godot remote-debugger receiver behind the profiling tools
+    ├── godot-variant.ts         # Variant subset the remote debugger speaks on the wire
     ├── autoload-ini.ts          # project.godot [autoload] INI primitives
     ├── run-script-policy.ts     # Declarative Tier 1/2/3 rule table + evaluateScript() for run_script / run_project
     ├── gdscript-scanner.ts      # Hand-written GDScript tokenizer backing the run_script security gate

--- a/docs/security.md
+++ b/docs/security.md
@@ -155,6 +155,22 @@ A frame with no token, or the wrong token, gets `{"error": "Unauthorized: invali
 
 ---
 
+## The profiler debug channel
+
+`run_project({ profiling: true })` opens a **second** local TCP channel, and it is not the bridge. Before spawning Godot the server binds a listener on `127.0.0.1:0` and passes `--remote-debug tcp://127.0.0.1:<port>` on the command line, so the engine dials back into it and speaks Godot's own remote-debugger protocol. The measurements are the stock editor ones — nothing is injected into the project — but the channel's properties differ from the bridge's in one way that matters.
+
+**This channel has no token.** The bridge authenticates every frame because both ends are ours. Godot defines the debugger protocol, there is no field to carry a secret, and the engine would not check one. The listener therefore accepts the first connection that arrives and destroys every later one. That is the same trust assumption the bridge token already concedes it cannot exceed: a process able to scan the local TCP table and win the race between bind and the engine's dial-back can equally read `MCP_SESSION_TOKEN` out of the spawned engine's environment and drive the _authenticated_ bridge, which is strictly more powerful. The missing token here does not open a door that a same-user process did not already have.
+
+**What a hostile peer could do, and where it stops.** It is confined to the profiler. The receiver acts on five message names — `set_pid`, `debug_enter`, `servers:function_signature`, `servers:profile_frame` and `servers:profile_total` — and drops everything else. None of them reaches script execution, the filesystem, process control, or any other tool's behaviour; the profiler's state is read only by the three profiling tools. The realistic ceiling is fabricated profiling numbers and denial of profiling for the rest of the session. A peer that connects but never speaks the protocol surfaces as a `profile_timeout` within five seconds, and the engine's own "unable to connect" lands in `get_debug_output`. A peer that _does_ speak it can return plausible-looking measurements with no signal. Treat profiler output as measurement data, not as a trusted assertion about your project.
+
+**Errors still do not pause the game.** A connected debugger normally halts the engine on a script error or `breakpoint`. Every `debug_enter` is answered immediately with `continue`, so profiling mode preserves the behaviour documented under "Runtime errors and `breakpoint`" — the engine runs past errors, `SCRIPT ERROR` output keeps reaching stderr, and `breakpoint` remains a no-op. Verified empirically against a project with a deliberate runtime error: stderr was byte-identical with and without `--remote-debug`, and the game ran on past the fault.
+
+**Lifetime.** The listener is bound only for spawned sessions, and only when `profiling: true` was passed at launch — it cannot be added to a running session, and `attach_project` never has one. It is closed by `stop_project` (including when the spawn failed and no process exists), by a failed spawn, by the next `run_project` or `attach_project`, and by the server's own shutdown handlers. It never outlives the server process.
+
+**Not covered by strict mode.** `GODOT_MCP_STRICT` and `GODOT_MCP_DISABLE_ELICITATION` govern what GDScript may run; they say nothing about this channel. `profiling: true` is a parameter on `run_project` and inherits that tool's pre-flight scan and session-confirmation gate, but strict mode does not separately refuse to open the debugger port.
+
+---
+
 ## Strict mode
 
 `GODOT_MCP_STRICT=true` is read once at process start. When enabled:
@@ -249,6 +265,8 @@ Audit failure (disk full, permission denied) is logged via `logDebug` and never 
 This section exists because the doctrine at the top of this document demands it: a best-effort filter that hides its own holes is worse than one that documents them.
 
 - **No runtime sandbox.** The gate is static-analysis only. Bridge authentication is a per-session token, not process isolation.
+- **The profiler debug channel is unauthenticated.** Godot defines the remote-debugger protocol and it has no place for a token, so the listener accepts the first connection that reaches it. A same-user process that wins that race can feed the server fabricated profiling data. See "The profiler debug channel" — it cannot reach anything beyond the profiler, and it is a strictly weaker position than reading the bridge token from the engine's environment.
+- **Loopback is not a boundary in every host configuration.** Both listeners bind `127.0.0.1` and are unreachable from the network, but a Linux process under WSL2 in mirrored networking mode shares the Windows host's loopback. The bridge is token-protected there; the profiler channel is not.
 - **No GDScript AST parse.** The tokenizer is line-oriented and does not track variable assignments.
 - **Identifier aliasing / dataflow is invisible.** `var f = FileAccess; f.open(...)` — or any indirection through a local variable — defeats every chain-based rule, because the scanner is token-level, not a dataflow analysis. This is a structural limit of tokenizer-level matching, not something the next rule addition can close.
 - **Inline scene scripts and instance overrides are not scanned by `run_project`'s pre-flight.** `[sub_resource type="GDScript"]` embeds GDScript source directly inside a `.tscn`; `[instance]` property overrides can also carry code-bearing values. Neither is chased. (Subscene _ext_resource_ recursion — scripts attached to a referenced PackedScene — IS scanned as of this release; see "`run_project` pre-flight".)

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -40,12 +40,12 @@ Both `run_project` and `attach_project` wait for the bridge before returning suc
 
 A capture returns the same three things the editor's Profiler tab shows:
 
-| Field        | Editor equivalent                                                                                                                                                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `rows[]`     | The **Script Functions** list. `function`, `file`, `line` (the tooltip's `res://…gd:371`), summed `calls`, own `selfMs` and inclusive `totalMs`, per-frame averages, `msPerCall` (the editor's "Average Time"), `percentOfFrame` ("Frame %"), and `peak` frame |
-| `frame`      | The **Frame Time** category: `frameMs`, `processMs`, `physicsMs`, `physicsFrameMs`, `scriptMs`, each as `{ avg, max }` over the capture                                                                                                                        |
-| `servers[]`  | One entry per server category (`audio_thread`, `physics_2d`, …) with its functions, in milliseconds per frame                                                                                                                                                  |
-| `worstFrame` | The slowest single frame: its timings plus its top 30 functions by inclusive time — the spike you would click in the editor's graph                                                                                                                            |
+| Field        | Editor equivalent                                                                                                                                                                                                                                                                                                                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `rows[]`     | The **Script Functions** list. `function`, `file`, `line` (the tooltip's `res://…gd:371`), summed `calls`, own `selfMs` and inclusive `totalMs`, per-frame averages, `msPerCall` (the editor's "Average Time"), `percentOfFrame` ("Frame %", a share of the capture's own average frame, not of a 16.67 ms target), and `peak` frame |
+| `frame`      | The **Frame Time** category: `frameMs`, `processMs`, `physicsMs`, `physicsFrameMs`, `scriptMs`, each as `{ avg, max }` over the capture                                                                                                                                                                                              |
+| `servers[]`  | One entry per server category (`audio_thread`, `physics_2d`, …) with its functions, in milliseconds per frame                                                                                                                                                                                                                        |
+| `worstFrame` | The slowest single frame: its timings plus its top 30 functions by inclusive time — the spike you would click in the editor's graph                                                                                                                                                                                                  |
 
 `sort` ranks rows by `selfMs` (default), `totalMs`, or `calls`. Milliseconds are rounded to four decimals.
 
@@ -53,10 +53,13 @@ Reading the numbers:
 
 - Times are elapsed wall clock, including waits — not CPU utilization. Inclusive rows overlap, so summing `totalMs` is meaningless.
 - Totals sum the received frames after the first, which is discarded: enabling the profiler inside a running VM call gives that sample a zero start timestamp.
-- Godot picks the rows it sends by inclusive time and caps them at `captureLimit`. `limitReached` and `frameGaps` say when rows or whole frames are missing; a function that is absent is not a function that is free.
-- The injected `mcp_bridge.gd` polls its socket every frame, so it shows up in the rows like any other script. That is real observer overhead (well under 0.05 ms/frame in practice), not a measurement artifact.
+- Godot picks the rows it sends by inclusive time and caps them at `captureLimit`. `limitReached`, `frameGaps` and `undecodablePackets` say when rows, whole frames, or packets are missing; a function that is absent is not a function that is free.
+- Totals are summed from the frame packets. The engine's own `servers:profile_total` is capped by the same `captureLimit` and carries nothing the frames did not, while top-N membership rotates between frames — so summing them covers strictly more functions than that packet does.
+- The injected `mcp_bridge.gd` polls its socket every frame, so it shows up in the rows like any other script. That is real observer overhead (well under 0.05 ms/frame in practice), not a measurement artifact. A `run_script` you execute during a capture is profiled the same way and appears under its own generated script name — discount it when reading a capture you drove yourself.
 - Native engine calls are not profiled as separate rows (the editor's "Display internal functions" toggle), so `selfMs` matches the editor's Self column in its default configuration.
-- A capture stops itself at its time limit, and `stop_project` ends it along with the session.
+- A capture stops itself at its time limit, measured from the first frame folded rather than from the enable round trip. `stop_project` ends it along with the session.
+- A capture that folded no usable frames errors rather than returning zeroes: the first frame received is always discarded, so a window shorter than two rendered frames has nothing to average.
+- A finished capture stays readable after the game exits, so the capture taken just before a crash can still be ranked.
 
 While the debugger is attached, a script error or a `breakpoint` would normally pause the game; the server answers every break with `continue`, so the game keeps running and the error still shows up in `get_debug_output`.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,16 +4,16 @@ The full MCP tool reference for Godot MCP Runtime. This file always reflects `ma
 
 ## Project Management
 
-| Tool               | Description                                                                                                                                                                             |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `launch_editor`    | Open the Godot editor GUI for a project                                                                                                                                                 |
-| `run_project`      | Run a project and inject the MCP bridge. Pass `background: true` to hide the window; pass `bridgePort` (integer 1–65535) to pin the bridge port — auto-selects a free port when omitted |
-| `attach_project`   | Inject the MCP bridge for a project you'll launch yourself. Pass `bridgePort` (integer 1–65535) to pin a specific port — auto-selects a free port when omitted                          |
-| `detach_project`   | Remove the injected bridge after manual-launch use, leaving the external process alone                                                                                                  |
-| `stop_project`     | Stop the running project and remove the bridge (also detaches attached-mode state)                                                                                                      |
-| `get_debug_output` | Read stdout/stderr from an MCP-spawned project (unavailable in attached mode)                                                                                                           |
-| `list_projects`    | Find Godot projects in a directory                                                                                                                                                      |
-| `get_project_info` | Get project metadata and Godot version                                                                                                                                                  |
+| Tool               | Description                                                                                                                                                                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `launch_editor`    | Open the Godot editor GUI for a project                                                                                                                                                                                                  |
+| `run_project`      | Run a project and inject the MCP bridge. Pass `background: true` to hide the window; `profiling: true` to enable the profiling tools; pass `bridgePort` (integer 1–65535) to pin the bridge port — auto-selects a free port when omitted |
+| `attach_project`   | Inject the MCP bridge for a project you'll launch yourself. Pass `bridgePort` (integer 1–65535) to pin a specific port — auto-selects a free port when omitted                                                                           |
+| `detach_project`   | Remove the injected bridge after manual-launch use, leaving the external process alone                                                                                                                                                   |
+| `stop_project`     | Stop the running project and remove the bridge (also detaches attached-mode state)                                                                                                                                                       |
+| `get_debug_output` | Read stdout/stderr from an MCP-spawned project (unavailable in attached mode)                                                                                                                                                            |
+| `list_projects`    | Find Godot projects in a directory                                                                                                                                                                                                       |
+| `get_project_info` | Get project metadata and Godot version                                                                                                                                                                                                   |
 
 ## Runtime (requires `run_project` or `attach_project` first)
 
@@ -27,6 +27,38 @@ Both `run_project` and `attach_project` wait for the bridge before returning suc
 | `run_script`      | Execute arbitrary GDScript at runtime with full SceneTree access                                                                        |
 
 `take_screenshot` defaults to `responseMode: "preview"` — the full PNG is saved to `.mcp/screenshots/` and a 960x540-bounded preview is returned inline. Use `"full"` for pixel-level inspection or `"path_only"` to skip the inline image.
+
+## Profiling (requires `run_project` with `profiling: true`)
+
+`profiling: true` adds `--remote-debug` to the launch, so the numbers are Godot's own editor profiler measurements. The channel is set at launch: an already-running session, and every `attach_project` session, returns "Profiling is not enabled for this session."
+
+| Tool              | Description                                                                               |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| `profile_project` | Capture a window (default 5 s, max 60) and return the most expensive GDScript functions   |
+| `start_profiler`  | Start a capture and return immediately, so runtime tools can drive the game while it runs |
+| `stop_profiler`   | Stop (or re-read) that capture and rank its functions                                     |
+
+A capture returns the same three things the editor's Profiler tab shows:
+
+| Field        | Editor equivalent                                                                                                                                                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rows[]`     | The **Script Functions** list. `function`, `file`, `line` (the tooltip's `res://…gd:371`), summed `calls`, own `selfMs` and inclusive `totalMs`, per-frame averages, `msPerCall` (the editor's "Average Time"), `percentOfFrame` ("Frame %"), and `peak` frame |
+| `frame`      | The **Frame Time** category: `frameMs`, `processMs`, `physicsMs`, `physicsFrameMs`, `scriptMs`, each as `{ avg, max }` over the capture                                                                                                                        |
+| `servers[]`  | One entry per server category (`audio_thread`, `physics_2d`, …) with its functions, in milliseconds per frame                                                                                                                                                  |
+| `worstFrame` | The slowest single frame: its timings plus its top 30 functions by inclusive time — the spike you would click in the editor's graph                                                                                                                            |
+
+`sort` ranks rows by `selfMs` (default), `totalMs`, or `calls`. Milliseconds are rounded to four decimals.
+
+Reading the numbers:
+
+- Times are elapsed wall clock, including waits — not CPU utilization. Inclusive rows overlap, so summing `totalMs` is meaningless.
+- Totals sum the received frames after the first, which is discarded: enabling the profiler inside a running VM call gives that sample a zero start timestamp.
+- Godot picks the rows it sends by inclusive time and caps them at `captureLimit`. `limitReached` and `frameGaps` say when rows or whole frames are missing; a function that is absent is not a function that is free.
+- The injected `mcp_bridge.gd` polls its socket every frame, so it shows up in the rows like any other script. That is real observer overhead (well under 0.05 ms/frame in practice), not a measurement artifact.
+- Native engine calls are not profiled as separate rows (the editor's "Display internal functions" toggle), so `selfMs` matches the editor's Self column in its default configuration.
+- A capture stops itself at its time limit, and `stop_project` ends it along with the session.
+
+While the debugger is attached, a script error or a `breakpoint` would normally pause the game; the server answers every break with `continue`, so the game keeps running and the error still shows up in `get_debug_output`.
 
 ## Scene Editing (headless)
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -68,6 +68,12 @@ import {
   handleDisconnectSignal,
 } from './tools/node-tools.js';
 
+import {
+  handleProfileProject,
+  handleStartProfiler,
+  handleStopProfiler,
+} from './tools/profiler-tools.js';
+
 import { handleValidate } from './tools/validate-tools.js';
 
 export const toolDispatch = {
@@ -111,6 +117,11 @@ export const toolDispatch = {
   get_node_signals: handleGetNodeSignals,
   connect_signal: handleConnectSignal,
   disconnect_signal: handleDisconnectSignal,
+
+  // Profiler tools
+  profile_project: handleProfileProject,
+  start_profiler: handleStartProfiler,
+  stop_profiler: handleStopProfiler,
 
   // Validate tools
   validate: handleValidate,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { autoloadToolDefinitions } from './tools/autoload-tools.js';
 import { projectToolDefinitions } from './tools/project-tools.js';
 import { sceneToolDefinitions } from './tools/scene-tools.js';
 import { nodeToolDefinitions } from './tools/node-tools.js';
+import { profilerToolDefinitions } from './tools/profiler-tools.js';
 import { validateToolDefinitions } from './tools/validate-tools.js';
 
 export const allToolDefinitions = [
@@ -32,6 +33,7 @@ export const allToolDefinitions = [
   ...projectToolDefinitions,
   ...sceneToolDefinitions,
   ...nodeToolDefinitions,
+  ...profilerToolDefinitions,
   ...validateToolDefinitions,
 ];
 
@@ -42,6 +44,7 @@ Tool categories:
 - Scene editing (headless): create_scene, add_node, load_sprite, save_scene, export_mesh_library, batch_scene_operations
 - Node editing (headless): delete_nodes, set_node_properties, get_node_properties, attach_script, get_scene_tree, duplicate_node, get_node_signals, connect_signal, disconnect_signal
 - Runtime (requires run_project or attach_project): take_screenshot, simulate_input, get_ui_elements, run_script
+- Profiling (requires run_project with profiling: true): profile_project, start_profiler, stop_profiler
 - Project config (no Godot process): list_autoloads, add_autoload, remove_autoload, update_autoload, get_project_files, search_project, get_scene_dependencies, get_project_settings
 - Validation: validate
 
@@ -52,7 +55,8 @@ Key behaviors:
 - attach_project is the fallback path for a manually launched Godot process. It injects the bridge and marks the project active, but it does not spawn Godot or capture stdout/stderr.
 - click_element in simulate_input resolves by node path or node name (BFS search), NOT by visible text. Use get_ui_elements to discover valid element identifiers.
 - run_script expects GDScript with "extends RefCounted" and "func execute(scene_tree: SceneTree) -> Variant".
-- run_project spawns Godot without -d so runtime errors do not pause execution; the \`breakpoint\` keyword in user code is a no-op (no debugger is attached). SCRIPT ERROR output and GDScript backtraces still appear in stderr.`;
+- run_project spawns Godot without -d so runtime errors do not pause execution; the \`breakpoint\` keyword in user code is a no-op (no debugger is attached). SCRIPT ERROR output and GDScript backtraces still appear in stderr.
+- profiling: true attaches Godot's own remote debugger for the profiling tools. Errors and \`breakpoint\` still do not pause the game — the server answers every debugger break with continue.`;
 
 /**
  * Build the request-scoped context backed by a live MCP `Server`. Lives here

--- a/src/mcp.types.ts
+++ b/src/mcp.types.ts
@@ -3,6 +3,7 @@ import type { McpContext } from './utils/mcp-context.js';
 import type { Result } from './utils/result.js';
 import type { autoloadToolDefinitions } from './tools/autoload-tools.js';
 import type { nodeToolDefinitions } from './tools/node-tools.js';
+import type { profilerToolDefinitions } from './tools/profiler-tools.js';
 import type { projectToolDefinitions } from './tools/project-tools.js';
 import type { runtimeToolDefinitions } from './tools/runtime-tools.js';
 import type { sceneToolDefinitions } from './tools/scene-tools.js';
@@ -71,6 +72,7 @@ export type ToolHandler = (
 export type ToolName = (
   | typeof autoloadToolDefinitions
   | typeof nodeToolDefinitions
+  | typeof profilerToolDefinitions
   | typeof projectToolDefinitions
   | typeof runtimeToolDefinitions
   | typeof sceneToolDefinitions

--- a/src/tools/profiler-tools.ts
+++ b/src/tools/profiler-tools.ts
@@ -8,6 +8,7 @@ import { ok, err, type Result } from '../utils/result.js';
 import {
   CAPTURE_LIMIT_MAX,
   PROFILE_SORTS,
+  PROFILE_TOP_MAX,
   ProfilerError,
   type DebuggerProfiler,
   type ProfileSort,
@@ -27,9 +28,59 @@ const sortProperty = {
     'Rank by own time ("selfMs", default), inclusive time ("totalMs"), or invocation count ("calls").',
 } as const;
 
+const captureLimitProperty = {
+  type: 'number',
+  description:
+    'Rows the engine puts in each frame packet, 16..512 (default: 512). Godot selects them by inclusive time, so a lower limit hides cheap functions and sets limitReached.',
+} as const;
+
 const topProperty = {
   type: 'number',
   description: 'How many functions to return, 1..100 (default: 20).',
+} as const;
+
+const statSchema = {
+  type: 'object',
+  properties: { avg: { type: 'number' }, max: { type: 'number' } },
+} as const;
+
+const frameTimingsSchema = {
+  type: 'object',
+  properties: {
+    frameMs: statSchema,
+    processMs: statSchema,
+    physicsMs: statSchema,
+    physicsFrameMs: statSchema,
+    scriptMs: statSchema,
+  },
+} as const;
+
+const rowSchema = {
+  type: 'object',
+  properties: {
+    signature: { type: 'string' },
+    function: { type: 'string' },
+    file: { type: 'string' },
+    line: { type: 'number' },
+    sourceResolved: { type: 'boolean' },
+    calls: { type: 'number' },
+    selfMs: { type: 'number' },
+    totalMs: { type: 'number' },
+    callsPerFrame: { type: 'number' },
+    selfMsPerFrame: { type: 'number' },
+    totalMsPerFrame: { type: 'number' },
+    msPerCall: { type: 'number' },
+    percentOfFrame: { type: 'number' },
+    peak: {
+      type: ['object', 'null'],
+      properties: {
+        frame: { type: 'number' },
+        calls: { type: 'number' },
+        selfMs: { type: 'number' },
+        totalMs: { type: 'number' },
+      },
+    },
+  },
 } as const;
 
 const captureResultSchema = {
@@ -41,14 +92,31 @@ const captureResultSchema = {
     firstFrame: { type: ['number', 'null'] },
     lastFrame: { type: ['number', 'null'] },
     frameGaps: { type: 'number' },
+    undecodablePackets: { type: 'number' },
     captureLimit: { type: 'number' },
     limitReached: { type: 'boolean' },
-    sort: { type: 'string' },
+    sort: { type: 'string', enum: [...PROFILE_SORTS] },
     functionsReceived: { type: 'number' },
     unresolvedFunctions: { type: 'number' },
-    frame: { type: 'object' },
-    servers: { type: 'array', items: { type: 'object' } },
-    rows: { type: 'array', items: { type: 'object' } },
+    frame: frameTimingsSchema,
+    servers: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          msPerFrame: { type: 'number' },
+          functions: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { name: { type: 'string' }, msPerFrame: { type: 'number' } },
+            },
+          },
+        },
+      },
+    },
+    rows: { type: 'array', items: rowSchema },
     worstFrame: { type: ['object', 'null'] },
   },
 } as const;
@@ -57,8 +125,8 @@ export const profilerToolDefinitions = [
   {
     name: 'profile_project',
     description:
-      "Capture a window of Godot's function profiler — the editor's Profiler tab numbers. Requires run_project with profiling: true. Blocks for `seconds` (default 5). Times are elapsed, not CPU; inclusive rows overlap — never sum totalMs. Returns: rows (file, line, function, calls, selfMs/totalMs, per-frame averages, percentOfFrame, peak frame), frame budget (frameMs/processMs/physicsMs/scriptMs, avg+max), servers, worstFrame, frames, frameGaps, limitReached. Errors if profiling was not enabled at launch.",
-    annotations: { readOnlyHint: true },
+      "Capture a window of Godot's function profiler — the editor's Profiler tab numbers. Requires run_project with profiling: true. Blocks for `seconds` (default 5). Times are elapsed, not CPU; inclusive rows overlap — never sum totalMs. Returns: rows (function, file, line, calls, selfMs/totalMs, per-frame averages, percentOfFrame, peak), the frame budget, servers, worstFrame, plus frames/frameGaps/limitReached for capture quality. Errors if profiling was off at launch or a capture is already open.",
+    annotations: { readOnlyHint: false, destructiveHint: false },
     inputSchema: {
       type: 'object',
       properties: {
@@ -68,6 +136,7 @@ export const profilerToolDefinitions = [
         },
         top: topProperty,
         sort: sortProperty,
+        captureLimit: captureLimitProperty,
       },
       required: [],
     },
@@ -77,7 +146,7 @@ export const profilerToolDefinitions = [
     name: 'start_profiler',
     description:
       'Start a profiler capture and return immediately, so simulate_input, run_script and screenshots can drive the game while it records. Requires run_project with profiling: true. Stops itself after `seconds` (default 30, max 60); call stop_profiler for the results. Returns: active, firstFrame, captureLimit, maxSeconds. Use profile_project instead for an unattended window. Errors if a capture is already running or profiling was not enabled at launch.',
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: false, destructiveHint: false },
     inputSchema: {
       type: 'object',
       properties: {
@@ -86,11 +155,7 @@ export const profilerToolDefinitions = [
           description:
             'Maximum capture duration before the automatic stop, greater than 0 and at most 60 (default: 30).',
         },
-        captureLimit: {
-          type: 'number',
-          description:
-            'Rows the engine puts in each frame packet, 16..512 (default: 512). Godot selects them by inclusive time, so a lower limit hides cheap functions.',
-        },
+        captureLimit: captureLimitProperty,
       },
       required: [],
     },
@@ -108,7 +173,7 @@ export const profilerToolDefinitions = [
     name: 'stop_profiler',
     description:
       'Stop the capture started by start_profiler and rank the recorded functions; a capture that already hit its time limit is read back as-is, and can be re-read with a different sort. Times are elapsed, not CPU; inclusive rows overlap — never sum totalMs. Returns: the same payload as profile_project — rows (file, line, function, calls, selfMs/totalMs, per-frame averages, percentOfFrame, peak frame), frame budget, servers, worstFrame, frames, frameGaps, limitReached. Errors if no capture was started.',
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: false, destructiveHint: false },
     inputSchema: {
       type: 'object',
       properties: {
@@ -130,6 +195,16 @@ export const profilerToolDefinitions = [
  */
 function requireProfiler(runner: GodotRunner): Result<DebuggerProfiler, ToolResponse> {
   if (runner.activeProfiler === null) {
+    // "Nothing is running" and "running without profiling" have different
+    // fixes, and every sibling runtime tool already draws this line.
+    if (!runner.activeSessionMode || !runner.activeProjectPath) {
+      return err(
+        createErrorResponse('No active runtime session. A project must be running to profile it.', [
+          'Use run_project with profiling: true to start a Godot project first',
+          'Profiling cannot be added to a session that is already running',
+        ]),
+      );
+    }
     return err(
       createErrorResponse('Profiling is not enabled for this session.', [
         'Call run_project with profiling: true — the debugger channel is set at launch and cannot be added later',
@@ -137,7 +212,10 @@ function requireProfiler(runner: GodotRunner): Result<DebuggerProfiler, ToolResp
       ]),
     );
   }
-  if (runner.activeProcess?.hasExited === true) {
+  const profiler = runner.activeProfiler;
+  // A finished capture outlives the engine: re-ranking folded data needs no
+  // process, and the capture taken just before a crash is the one worth having.
+  if (runner.activeProcess?.hasExited === true && !profiler.hasResult) {
     return err(
       createErrorResponse('The spawned Godot process has exited and cannot be profiled.', [
         'Use get_debug_output to inspect the last captured logs',
@@ -145,7 +223,27 @@ function requireProfiler(runner: GodotRunner): Result<DebuggerProfiler, ToolResp
       ]),
     );
   }
-  return ok(runner.activeProfiler);
+  return ok(profiler);
+}
+
+/**
+ * Range-check `top` here rather than leaving it to `stop()`. A capture window
+ * runs for seconds before that check is reached, so a bad value would cost the
+ * whole window before erroring.
+ */
+function parseTop(args: OperationParams): Result<number, ToolResponse> {
+  const raw = optionalNumber(args, 'top');
+  if (!raw.ok) return raw;
+  if (raw.value === undefined) return ok(DEFAULT_TOP);
+  if (!Number.isInteger(raw.value) || raw.value < 1 || raw.value > PROFILE_TOP_MAX) {
+    return err(
+      createErrorResponse(
+        `Invalid top: must be an integer in [1, ${PROFILE_TOP_MAX}] (got: ${raw.value})`,
+        [`Omit top to return the default of ${DEFAULT_TOP} rows`],
+      ),
+    );
+  }
+  return ok(raw.value);
 }
 
 function parseSort(args: OperationParams): Result<ProfileSort, ToolResponse> {
@@ -182,6 +280,14 @@ function profilerFailure(error: unknown): ToolResponse {
       'The Godot process ended or dropped the debugger connection',
       'Call stop_project, then run_project with profiling: true again',
     ],
+    profile_no_frames: [
+      'Capture for longer — a window shorter than two rendered frames has nothing to average',
+      'Godot only emits profiler frames while it renders; make sure the window is not minimized or paused',
+    ],
+    profile_bad_frame: [
+      'This Godot version may lay out profiler frames differently than the server expects',
+      'Report the Godot version — get_project_info returns it',
+    ],
   };
   return createErrorResponse(message, solutions[error.code]);
 }
@@ -196,7 +302,9 @@ export async function handleProfileProject(
 
   const seconds = optionalNumber(args, 'seconds');
   if (!seconds.ok) return seconds;
-  const top = optionalNumber(args, 'top');
+  const captureLimit = optionalNumber(args, 'captureLimit');
+  if (!captureLimit.ok) return captureLimit;
+  const top = parseTop(args);
   if (!top.ok) return top;
   const sort = parseSort(args);
   if (!sort.ok) return sort;
@@ -207,8 +315,9 @@ export async function handleProfileProject(
   try {
     const result = await profiler.value.captureWindow(
       seconds.value ?? DEFAULT_WINDOW_SECONDS,
-      top.value ?? DEFAULT_TOP,
+      top.value,
       sort.value,
+      captureLimit.value ?? CAPTURE_LIMIT_MAX,
     );
     return createStructuredResponse({ ...result });
   } catch (error: unknown) {
@@ -247,7 +356,7 @@ export async function handleStopProfiler(
 ): Promise<HandlerResult> {
   args = normalizeParameters(args);
 
-  const top = optionalNumber(args, 'top');
+  const top = parseTop(args);
   if (!top.ok) return top;
   const sort = parseSort(args);
   if (!sort.ok) return sort;
@@ -256,7 +365,7 @@ export async function handleStopProfiler(
   if (!profiler.ok) return profiler;
 
   try {
-    const result = await profiler.value.stop(top.value ?? DEFAULT_TOP, sort.value);
+    const result = await profiler.value.stop(top.value, sort.value);
     return createStructuredResponse({ ...result });
   } catch (error: unknown) {
     return err(profilerFailure(error));

--- a/src/tools/profiler-tools.ts
+++ b/src/tools/profiler-tools.ts
@@ -1,0 +1,264 @@
+import type { GodotRunner } from '../utils/godot-runner.js';
+import type { HandlerResult, OperationParams, ToolDefinition, ToolResponse } from '../mcp.types.js';
+import { normalizeParameters } from '../utils/parameter-conversion.js';
+import { createErrorResponse, getErrorMessage } from '../utils/error-response.js';
+import { createStructuredResponse } from '../utils/structured-response.js';
+import { optionalNumber, optionalString } from '../utils/arg-parsing.js';
+import { ok, err, type Result } from '../utils/result.js';
+import {
+  CAPTURE_LIMIT_MAX,
+  PROFILE_SORTS,
+  ProfilerError,
+  type DebuggerProfiler,
+  type ProfileSort,
+} from '../utils/profiler.js';
+
+const DEFAULT_WINDOW_SECONDS = 5;
+const DEFAULT_MAX_SECONDS = 30;
+const DEFAULT_TOP = 20;
+const DEFAULT_SORT: ProfileSort = 'selfMs';
+
+// --- Tool definitions ---
+
+const sortProperty = {
+  type: 'string',
+  enum: [...PROFILE_SORTS],
+  description:
+    'Rank by own time ("selfMs", default), inclusive time ("totalMs"), or invocation count ("calls").',
+} as const;
+
+const topProperty = {
+  type: 'number',
+  description: 'How many functions to return, 1..100 (default: 20).',
+} as const;
+
+const captureResultSchema = {
+  type: 'object',
+  properties: {
+    seconds: { type: 'number' },
+    frames: { type: 'number' },
+    framesReceived: { type: 'number' },
+    firstFrame: { type: ['number', 'null'] },
+    lastFrame: { type: ['number', 'null'] },
+    frameGaps: { type: 'number' },
+    captureLimit: { type: 'number' },
+    limitReached: { type: 'boolean' },
+    sort: { type: 'string' },
+    functionsReceived: { type: 'number' },
+    unresolvedFunctions: { type: 'number' },
+    frame: { type: 'object' },
+    servers: { type: 'array', items: { type: 'object' } },
+    rows: { type: 'array', items: { type: 'object' } },
+    worstFrame: { type: ['object', 'null'] },
+  },
+} as const;
+
+export const profilerToolDefinitions = [
+  {
+    name: 'profile_project',
+    description:
+      "Capture a window of Godot's function profiler — the editor's Profiler tab numbers. Requires run_project with profiling: true. Blocks for `seconds` (default 5). Times are elapsed, not CPU; inclusive rows overlap — never sum totalMs. Returns: rows (file, line, function, calls, selfMs/totalMs, per-frame averages, percentOfFrame, peak frame), frame budget (frameMs/processMs/physicsMs/scriptMs, avg+max), servers, worstFrame, frames, frameGaps, limitReached. Errors if profiling was not enabled at launch.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        seconds: {
+          type: 'number',
+          description: 'Capture duration in seconds, greater than 0 and at most 60 (default: 5).',
+        },
+        top: topProperty,
+        sort: sortProperty,
+      },
+      required: [],
+    },
+    outputSchema: captureResultSchema,
+  },
+  {
+    name: 'start_profiler',
+    description:
+      'Start a profiler capture and return immediately, so simulate_input, run_script and screenshots can drive the game while it records. Requires run_project with profiling: true. Stops itself after `seconds` (default 30, max 60); call stop_profiler for the results. Returns: active, firstFrame, captureLimit, maxSeconds. Use profile_project instead for an unattended window. Errors if a capture is already running or profiling was not enabled at launch.',
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        seconds: {
+          type: 'number',
+          description:
+            'Maximum capture duration before the automatic stop, greater than 0 and at most 60 (default: 30).',
+        },
+        captureLimit: {
+          type: 'number',
+          description:
+            'Rows the engine puts in each frame packet, 16..512 (default: 512). Godot selects them by inclusive time, so a lower limit hides cheap functions.',
+        },
+      },
+      required: [],
+    },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        active: { type: 'boolean' },
+        maxSeconds: { type: 'number' },
+        firstFrame: { type: ['number', 'null'] },
+        captureLimit: { type: 'number' },
+      },
+    },
+  },
+  {
+    name: 'stop_profiler',
+    description:
+      'Stop the capture started by start_profiler and rank the recorded functions; a capture that already hit its time limit is read back as-is, and can be re-read with a different sort. Times are elapsed, not CPU; inclusive rows overlap — never sum totalMs. Returns: the same payload as profile_project — rows (file, line, function, calls, selfMs/totalMs, per-frame averages, percentOfFrame, peak frame), frame budget, servers, worstFrame, frames, frameGaps, limitReached. Errors if no capture was started.',
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        top: topProperty,
+        sort: sortProperty,
+      },
+      required: [],
+    },
+    outputSchema: captureResultSchema,
+  },
+] as const satisfies readonly ToolDefinition[];
+
+// --- Helpers ---
+
+/**
+ * The profiler lives on the runner for as long as the spawned session does.
+ * Its absence is always the same user-facing story: this session was not
+ * launched with the debugger channel, so there is nothing to measure.
+ */
+function requireProfiler(runner: GodotRunner): Result<DebuggerProfiler, ToolResponse> {
+  if (runner.activeProfiler === null) {
+    return err(
+      createErrorResponse('Profiling is not enabled for this session.', [
+        'Call run_project with profiling: true — the debugger channel is set at launch and cannot be added later',
+        'Attached sessions cannot profile; use run_project instead of attach_project',
+      ]),
+    );
+  }
+  if (runner.activeProcess?.hasExited === true) {
+    return err(
+      createErrorResponse('The spawned Godot process has exited and cannot be profiled.', [
+        'Use get_debug_output to inspect the last captured logs',
+        'Call stop_project to clean up, then run_project with profiling: true again',
+      ]),
+    );
+  }
+  return ok(runner.activeProfiler);
+}
+
+function parseSort(args: OperationParams): Result<ProfileSort, ToolResponse> {
+  const raw = optionalString(args, 'sort');
+  if (!raw.ok) return raw;
+  if (raw.value === undefined) return ok(DEFAULT_SORT);
+  if (!PROFILE_SORTS.includes(raw.value as ProfileSort)) {
+    return err(
+      createErrorResponse(
+        `Invalid sort: must be one of ${PROFILE_SORTS.join(', ')} (got: ${raw.value})`,
+        ['Omit sort to rank by own time'],
+      ),
+    );
+  }
+  return ok(raw.value as ProfileSort);
+}
+
+function profilerFailure(error: unknown): ToolResponse {
+  const message = getErrorMessage(error);
+  if (!(error instanceof ProfilerError)) {
+    return createErrorResponse(`Profiling failed: ${message}`, [
+      'Check get_debug_output for runtime errors',
+    ]);
+  }
+  const solutions: Record<ProfilerError['code'], string[]> = {
+    bad_args: ['Pass values inside the documented ranges'],
+    profile_busy: ['Call stop_profiler to close the running capture first'],
+    profile_not_started: ['Call start_profiler first, or profile_project for a one-shot capture'],
+    profile_timeout: [
+      'Godot only emits profiler frames while it renders — make sure the window is not minimized or paused',
+      'Check get_debug_output for runtime errors',
+    ],
+    profile_disconnected: [
+      'The Godot process ended or dropped the debugger connection',
+      'Call stop_project, then run_project with profiling: true again',
+    ],
+  };
+  return createErrorResponse(message, solutions[error.code]);
+}
+
+// --- Handlers ---
+
+export async function handleProfileProject(
+  runner: GodotRunner,
+  args: OperationParams,
+): Promise<HandlerResult> {
+  args = normalizeParameters(args);
+
+  const seconds = optionalNumber(args, 'seconds');
+  if (!seconds.ok) return seconds;
+  const top = optionalNumber(args, 'top');
+  if (!top.ok) return top;
+  const sort = parseSort(args);
+  if (!sort.ok) return sort;
+
+  const profiler = requireProfiler(runner);
+  if (!profiler.ok) return profiler;
+
+  try {
+    const result = await profiler.value.captureWindow(
+      seconds.value ?? DEFAULT_WINDOW_SECONDS,
+      top.value ?? DEFAULT_TOP,
+      sort.value,
+    );
+    return createStructuredResponse({ ...result });
+  } catch (error: unknown) {
+    return err(profilerFailure(error));
+  }
+}
+
+export async function handleStartProfiler(
+  runner: GodotRunner,
+  args: OperationParams,
+): Promise<HandlerResult> {
+  args = normalizeParameters(args);
+
+  const seconds = optionalNumber(args, 'seconds');
+  if (!seconds.ok) return seconds;
+  const captureLimit = optionalNumber(args, 'captureLimit');
+  if (!captureLimit.ok) return captureLimit;
+
+  const profiler = requireProfiler(runner);
+  if (!profiler.ok) return profiler;
+
+  try {
+    const result = await profiler.value.start(
+      seconds.value ?? DEFAULT_MAX_SECONDS,
+      captureLimit.value ?? CAPTURE_LIMIT_MAX,
+    );
+    return createStructuredResponse({ ...result });
+  } catch (error: unknown) {
+    return err(profilerFailure(error));
+  }
+}
+
+export async function handleStopProfiler(
+  runner: GodotRunner,
+  args: OperationParams,
+): Promise<HandlerResult> {
+  args = normalizeParameters(args);
+
+  const top = optionalNumber(args, 'top');
+  if (!top.ok) return top;
+  const sort = parseSort(args);
+  if (!sort.ok) return sort;
+
+  const profiler = requireProfiler(runner);
+  if (!profiler.ok) return profiler;
+
+  try {
+    const result = await profiler.value.stop(top.value ?? DEFAULT_TOP, sort.value);
+    return createStructuredResponse({ ...result });
+  } catch (error: unknown) {
+    return err(profilerFailure(error));
+  }
+}

--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -103,6 +103,11 @@ export const runtimeToolDefinitions = [
           description:
             "TCP port for the MCP bridge. Omit to auto-select a free port (recommended). The chosen port is baked into the project's `mcp_bridge.gd` at inject time, so the running Godot listens on exactly this port.",
         },
+        profiling: {
+          type: 'boolean',
+          description:
+            "Attach Godot's own remote debugger so profile_project, start_profiler and stop_profiler can measure this session. Must be set at launch — a session already running cannot be profiled — and costs a little runtime overhead.",
+        },
       },
       required: ['projectPath'],
     },
@@ -913,8 +918,12 @@ export async function handleRunProject(
   if (!background.ok) return background;
   const isBackground = background.value === true;
 
+  const profiling = optionalBoolean(args, 'profiling');
+  if (!profiling.ok) return profiling;
+  const isProfiling = profiling.value === true;
+
   try {
-    await runner.runProject(projectPath, scene.value, isBackground, bridgePort.value);
+    await runner.runProject(projectPath, scene.value, isBackground, bridgePort.value, isProfiling);
 
     const bridgeResult = await runner.waitForBridge();
 
@@ -981,6 +990,9 @@ export async function handleRunProject(
     ];
     if (isBackground) {
       lines.push('- Background mode: window hidden, physical input blocked');
+    }
+    if (isProfiling) {
+      lines.push('- Profiling enabled: use profile_project or start_profiler');
     }
     const allWarnings = [
       ...scanFindings.map((f) => formatScanFinding(f.sourcePath, absProjectPath, f.match)),

--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -77,7 +77,7 @@ export const runtimeToolDefinitions = [
   {
     name: 'run_project',
     description:
-      'Spawn a Godot project as a child process with stdout/stderr captured. Required before take_screenshot, simulate_input, get_ui_elements, run_script, or get_debug_output. For a Godot process you launched yourself, use attach_project instead. Verifies MCP bridge readiness before returning success. Returns plain-text status with the assigned bridge port. Call stop_project when done. Errors if projectPath is not a Godot project or another session is already active.',
+      'Spawn a Godot project as a child process with stdout/stderr captured. Required before take_screenshot, simulate_input, get_ui_elements, run_script, or get_debug_output. Set profiling: true at launch to enable the profiler tools. Use attach_project for one you launched yourself. Verifies MCP bridge readiness before returning success. Returns status with the assigned bridge port. Call stop_project when done. Errors if projectPath is not a Godot project or another session is already active.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -487,7 +487,14 @@ export class GodotRunner {
     if (background) {
       spawnOptions.env = { ...spawnOptions.env, MCP_BACKGROUND: '1' };
     }
-    const proc = spawn(this.godotPath, cmdArgs, spawnOptions);
+    let proc;
+    try {
+      proc = spawn(this.godotPath, cmdArgs, spawnOptions);
+    } catch (err) {
+      // Nothing will dial the debugger listener now; don't strand the port.
+      this.closeProfiler();
+      throw err;
+    }
     const output: string[] = [];
     const errors: string[] = [];
 
@@ -531,6 +538,9 @@ export class GodotRunner {
       console.error('Failed to start Godot process:', err);
       errors.push(`Process error: ${err.message}`);
       godotProcess.hasExited = true;
+      // The engine will never dial back, so nothing can arrive on the debugger
+      // listener. Holding the port open until the next run_project is pointless.
+      this.closeProfiler();
     });
 
     this.activeProcess = godotProcess;
@@ -578,7 +588,11 @@ export class GodotRunner {
   }
 
   async stopProject(): Promise<RuntimeStopResult | null> {
+    // Release the debugger listener before any early return. A spawn that
+    // failed after the profiler bound leaves `activeProcess` null, and
+    // stop_project is exactly where the user goes to clean that up.
     if (!this.activeSessionMode) {
+      this.closeProfiler();
       return null;
     }
 
@@ -611,6 +625,9 @@ export class GodotRunner {
     }
 
     if (!this.activeProcess) {
+      this.closeProfiler();
+      this.activeSessionMode = null;
+      this.activeProjectPath = null;
       return null;
     }
 

--- a/src/utils/godot-runner.ts
+++ b/src/utils/godot-runner.ts
@@ -6,6 +6,7 @@ import { spawn } from 'child_process';
 import * as net from 'net';
 import { randomBytes } from 'crypto';
 import { BridgeManager } from './bridge-manager.js';
+import { DebuggerProfiler } from './profiler.js';
 import {
   DEFAULT_BRIDGE_PORT,
   encodeFrame,
@@ -116,6 +117,10 @@ export class GodotRunner {
   public activeProjectPath: string | null = null;
   public activeSessionMode: RuntimeSessionMode | null = null;
   public activeBridgePort: number | null = null;
+  // Debugger receiver for `run_project({ profiling: true })`. Bound before the
+  // spawn so `--remote-debug` has a port to dial, and torn down with the
+  // session. Null in attached mode — the channel is set at launch or never.
+  public activeProfiler: DebuggerProfiler | null = null;
   // Per-session bridge auth token. Spawned sessions deliver this via the
   // MCP_SESSION_TOKEN env var; attached sessions bake it into the injected
   // script (see BridgeManager.inject). Attached to every outgoing frame in
@@ -408,6 +413,7 @@ export class GodotRunner {
     scene?: string,
     background: boolean = false,
     bridgePort?: number,
+    profiling: boolean = false,
   ): Promise<GodotProcess> {
     if (!this.godotPath) {
       throw new Error(
@@ -420,6 +426,7 @@ export class GodotRunner {
     // expectedPath makes pollBridge's path guard fail immediately and mask
     // the real reason as a generic bridge timeout.
     projectPath = resolve(projectPath);
+    this.closeProfiler();
 
     if (this.activeSessionMode === 'spawned' && this.activeProcess) {
       logDebug('Killing existing Godot process before starting a new one');
@@ -456,6 +463,11 @@ export class GodotRunner {
     this.activeSessionMode = 'spawned';
 
     const cmdArgs = ['--path', projectPath];
+    if (profiling) {
+      this.activeProfiler = await DebuggerProfiler.create();
+      cmdArgs.push('--remote-debug', `tcp://127.0.0.1:${this.activeProfiler.port}`);
+      logDebug(`Profiling enabled (debugger port ${this.activeProfiler.port})`);
+    }
     if (scene && validateSubPath(projectPath, scene)) {
       logDebug(`Adding scene parameter: ${scene}`);
       cmdArgs.push(scene);
@@ -529,6 +541,7 @@ export class GodotRunner {
     // Resolve relative paths for the same reason as runProject — pollBridge
     // compares against the absolute path the bridge reports.
     projectPath = resolve(projectPath);
+    this.closeProfiler();
     if (this.activeSessionMode === 'spawned' && this.activeProcess) {
       await this.stopProject();
     } else if (
@@ -579,6 +592,7 @@ export class GodotRunner {
         logDebug(`Attached shutdown timed out or failed (continuing cleanup): ${err}`);
       }
       this.closeConnection();
+      this.closeProfiler();
       const projectPath = this.activeProjectPath;
       if (projectPath) {
         this.bridge.cleanup(projectPath);
@@ -608,6 +622,7 @@ export class GodotRunner {
       // Bridge may already be unreachable — proceed to kill.
     }
     this.closeConnection();
+    this.closeProfiler();
 
     logDebug('Stopping active Godot process');
     const proc = this.activeProcess.process;
@@ -647,6 +662,11 @@ export class GodotRunner {
     this.activeSessionToken = null;
 
     return result;
+  }
+
+  private closeProfiler(): void {
+    this.activeProfiler?.close();
+    this.activeProfiler = null;
   }
 
   hasActiveRuntimeSession(): boolean {

--- a/src/utils/godot-variant.ts
+++ b/src/utils/godot-variant.ts
@@ -1,0 +1,172 @@
+/**
+ * The bounded Variant subset Godot's remote debugger speaks on the wire.
+ *
+ * Debugger packets are `[uint32 length][Variant]`, and every Variant the
+ * profiler stream carries is a nil/bool/int/float/string/array or a packed
+ * numeric array. Objects, dictionaries and vectors are deliberately *not*
+ * decoded: an unrelated debugger packet must fail loudly instead of driving
+ * allocation from an attacker-shaped length field. Callers treat a decode
+ * failure as "not a message I care about" and move on.
+ *
+ * Separate from `bridge-protocol.ts` — that framing is ours and both ends are
+ * in this repo; this one is Godot's and only the engine defines it.
+ */
+
+/** Every value this codec can represent. */
+export type Variant = null | boolean | number | string | Variant[];
+
+/** Matches the engine's own debugger packet ceiling. */
+export const MAX_PACKET_BYTES = 16 * 1024 * 1024;
+
+const TYPE_NIL = 0;
+const TYPE_BOOL = 1;
+const TYPE_INT = 2;
+const TYPE_FLOAT = 3;
+const TYPE_STRING = 4;
+const TYPE_STRING_NAME = 21;
+const TYPE_ARRAY = 28;
+const TYPE_PACKED_BYTE_ARRAY = 29;
+const TYPE_PACKED_INT32_ARRAY = 30;
+const TYPE_PACKED_INT64_ARRAY = 31;
+const TYPE_PACKED_FLOAT32_ARRAY = 32;
+const TYPE_PACKED_FLOAT64_ARRAY = 33;
+const TYPE_PACKED_STRING_ARRAY = 34;
+
+// Bit 16 of the header word marks the 64-bit encoding of INT and FLOAT.
+const FLAG_WIDE = 1 << 16;
+const MAX_NESTING = 64;
+
+const padding = (length: number): number => (4 - (length % 4)) % 4;
+
+/**
+ * Encode one outgoing debugger command. Only the types the debugger accepts
+ * from us are supported — anything else is a bug in the caller, not a packet
+ * we should try to serialize.
+ */
+export function encodeVariant(value: Variant): Buffer {
+  if (value === null) {
+    const buf = Buffer.alloc(4);
+    buf.writeUInt32LE(TYPE_NIL, 0);
+    return buf;
+  }
+  if (typeof value === 'boolean') {
+    const buf = Buffer.alloc(8);
+    buf.writeUInt32LE(TYPE_BOOL, 0);
+    buf.writeUInt32LE(value ? 1 : 0, 4);
+    return buf;
+  }
+  if (typeof value === 'number') {
+    const buf = Buffer.alloc(12);
+    if (Number.isInteger(value)) {
+      buf.writeUInt32LE(TYPE_INT | FLAG_WIDE, 0);
+      buf.writeBigInt64LE(BigInt(value), 4);
+    } else {
+      buf.writeUInt32LE(TYPE_FLOAT | FLAG_WIDE, 0);
+      buf.writeDoubleLE(value, 4);
+    }
+    return buf;
+  }
+  if (typeof value === 'string') {
+    const raw = Buffer.from(value, 'utf8');
+    const head = Buffer.alloc(8);
+    head.writeUInt32LE(TYPE_STRING, 0);
+    head.writeUInt32LE(raw.length, 4);
+    return Buffer.concat([head, raw, Buffer.alloc(padding(raw.length))]);
+  }
+  if (Array.isArray(value)) {
+    const head = Buffer.alloc(8);
+    head.writeUInt32LE(TYPE_ARRAY, 0);
+    head.writeUInt32LE(value.length, 4);
+    return Buffer.concat([head, ...value.map(encodeVariant)]);
+  }
+  throw new Error('Unsupported outgoing debugger value');
+}
+
+/**
+ * Decode one incoming packet payload. Throws on truncation, trailing bytes,
+ * or a type outside the supported subset.
+ */
+export function decodeVariant(raw: Buffer): Variant {
+  let offset = 0;
+
+  const take = (size: number, read: (buf: Buffer, at: number) => number): number => {
+    if (offset + size > raw.length) throw new Error('Truncated Variant');
+    const value = read(raw, offset);
+    offset += size;
+    return value;
+  };
+  const u32 = (): number => take(4, (buf, at) => buf.readUInt32LE(at));
+  const readString = (): string => {
+    const size = u32();
+    const end = offset + size;
+    if (end + padding(size) > raw.length) throw new Error('Truncated string');
+    const value = raw.toString('utf8', offset, end);
+    offset = end + padding(size);
+    return value;
+  };
+
+  const item = (depth: number): Variant => {
+    if (depth > MAX_NESTING) throw new Error('Variant nesting limit');
+    const header = u32();
+    const kind = header & 0xffff;
+    const wide = (header & FLAG_WIDE) !== 0;
+    switch (kind) {
+      case TYPE_NIL:
+        return null;
+      case TYPE_BOOL:
+        return u32() !== 0;
+      case TYPE_INT:
+        return wide
+          ? Number(take(8, (buf, at) => Number(buf.readBigInt64LE(at))))
+          : take(4, (buf, at) => buf.readInt32LE(at));
+      case TYPE_FLOAT:
+        return wide
+          ? take(8, (buf, at) => buf.readDoubleLE(at))
+          : take(4, (buf, at) => buf.readFloatLE(at));
+      case TYPE_STRING:
+      case TYPE_STRING_NAME:
+        return readString();
+      case TYPE_PACKED_BYTE_ARRAY:
+      case TYPE_PACKED_INT32_ARRAY:
+      case TYPE_PACKED_INT64_ARRAY:
+      case TYPE_PACKED_FLOAT32_ARRAY:
+      case TYPE_PACKED_FLOAT64_ARRAY: {
+        const reader = PACKED_READERS[kind];
+        if (reader === undefined) throw new Error(`Unsupported debugger Variant ${header}`);
+        const [size, read] = reader;
+        const count = u32();
+        if (count > (raw.length - offset) / size) throw new Error('Invalid packed array length');
+        const values: Variant[] = [];
+        for (let i = 0; i < count; i++) values.push(take(size, read));
+        if (kind === TYPE_PACKED_BYTE_ARRAY) offset += padding(count);
+        return values;
+      }
+      case TYPE_ARRAY:
+      case TYPE_PACKED_STRING_ARRAY: {
+        // A typed (or shared) array sets flags we do not carry through.
+        if (header !== kind) throw new Error(`Unsupported debugger Variant ${header}`);
+        const count = u32() & 0x7fffffff;
+        if (count > (raw.length - offset) / 4) throw new Error('Invalid array length');
+        const values: Variant[] = [];
+        for (let i = 0; i < count; i++) {
+          values.push(kind === TYPE_ARRAY ? item(depth + 1) : readString());
+        }
+        return values;
+      }
+      default:
+        throw new Error(`Unsupported debugger Variant ${header}`);
+    }
+  };
+
+  const value = item(0);
+  if (offset !== raw.length) throw new Error('Trailing Variant bytes');
+  return value;
+}
+
+const PACKED_READERS: Record<number, [number, (buf: Buffer, at: number) => number]> = {
+  [TYPE_PACKED_BYTE_ARRAY]: [1, (buf, at) => buf.readUInt8(at)],
+  [TYPE_PACKED_INT32_ARRAY]: [4, (buf, at) => buf.readInt32LE(at)],
+  [TYPE_PACKED_INT64_ARRAY]: [8, (buf, at) => Number(buf.readBigInt64LE(at))],
+  [TYPE_PACKED_FLOAT32_ARRAY]: [4, (buf, at) => buf.readFloatLE(at)],
+  [TYPE_PACKED_FLOAT64_ARRAY]: [8, (buf, at) => buf.readDoubleLE(at)],
+};

--- a/src/utils/parameter-conversion.ts
+++ b/src/utils/parameter-conversion.ts
@@ -32,6 +32,7 @@ const parameterMappings = {
   case_sensitive: 'caseSensitive',
   file_types: 'fileTypes',
   max_results: 'maxResults',
+  capture_limit: 'captureLimit',
 } as const satisfies Record<string, string>;
 
 type ForwardMap = typeof parameterMappings;

--- a/src/utils/profiler.ts
+++ b/src/utils/profiler.ts
@@ -21,7 +21,9 @@ export type ProfilerErrorCode =
   | 'profile_busy'
   | 'profile_not_started'
   | 'profile_timeout'
-  | 'profile_disconnected';
+  | 'profile_disconnected'
+  | 'profile_no_frames'
+  | 'profile_bad_frame';
 
 export class ProfilerError extends Error {
   constructor(
@@ -45,6 +47,9 @@ export const PROFILE_TOP_MAX = 100;
 const WORST_FRAME_ROWS = 30;
 /** Every engine row is `[signature id, calls, self, total, internal]`. */
 const ROW_STRIDE = 5;
+/** Milliseconds are reported to this many decimals; below it is float noise. */
+const MS_DECIMALS = 4;
+const MS_ROUNDING = 10 ** MS_DECIMALS;
 
 const WAIT_CONNECT_MS = 5000;
 const WAIT_FIRST_FRAME_MS = 5000;
@@ -110,6 +115,11 @@ export interface ProfileResult {
   firstFrame: number | null;
   lastFrame: number | null;
   frameGaps: number;
+  /**
+   * Debugger packets dropped because the codec could not represent them. A
+   * non-zero value means the capture may be missing frames it was sent.
+   */
+  undecodablePackets: number;
   captureLimit: number;
   limitReached: boolean;
   sort: ProfileSort;
@@ -137,12 +147,16 @@ interface FrameRow {
 
 interface Capture {
   limit: number;
+  /** Window the caller asked for; the auto-stop is armed off the first frame. */
+  maxSeconds: number;
   startedAt: number;
   elapsedMs: number;
   /** Frames folded into the totals (excludes the discarded boundary frame). */
   frames: number;
   framesReceived: number;
   frameGaps: number;
+  /** Packets the codec could not represent while this capture was open. */
+  undecodablePackets: number;
   firstFrame: number | null;
   lastFrame: number | null;
   capped: boolean;
@@ -165,14 +179,35 @@ interface Waiter {
   timer: NodeJS.Timeout;
 }
 
+function badFrame(what: string): ProfilerError {
+  return new ProfilerError(
+    'profile_bad_frame',
+    `Unrecognized profiler frame layout (${what}) — this Godot version may not be supported`,
+  );
+}
+
 function asNumber(value: Variant | undefined): number {
-  if (typeof value !== 'number') throw new Error('Expected a number in a profiler frame');
+  if (typeof value !== 'number') throw badFrame('expected a number');
   return value;
+}
+
+/**
+ * Loop bounds and element counts must be real non-negative integers. Plain
+ * `asNumber` would accept a float — and a layout shift that lands a timing
+ * value where a count belongs makes `for (i < 0.016)` run once instead of
+ * throwing, walking `offset` off silently. Fail loudly on version drift.
+ */
+function asCount(value: Variant | undefined, limit: number): number {
+  const count = asNumber(value);
+  if (!Number.isSafeInteger(count) || count < 0 || count > limit) {
+    throw badFrame(`expected a count in [0, ${limit}], got ${count}`);
+  }
+  return count;
 }
 
 /** Trim float noise from the summary — these are milliseconds, not physics. */
 function roundNumbers<T>(value: T): T {
-  if (typeof value === 'number') return (Math.round(value * 1e4) / 1e4) as T;
+  if (typeof value === 'number') return (Math.round(value * MS_ROUNDING) / MS_ROUNDING) as T;
   if (Array.isArray(value)) return value.map(roundNumbers) as T;
   if (value !== null && typeof value === 'object') {
     return Object.fromEntries(
@@ -196,12 +231,20 @@ interface FrameSample {
   timings: FrameTimings;
   servers: Array<{ name: string; functions: Array<{ name: string; ms: number }> }>;
   rows: FrameRow[];
+  /**
+   * Rows the engine actually sent, before zero-call rows are dropped. The
+   * engine's `captureLimit` applies to this count, so the truncation check
+   * has to use it rather than the filtered `rows.length`.
+   */
+  rawRowCount: number;
 }
 
 /**
- * Split the engine's per-frame array. Layout: six timing fields, a server
- * count, that many `name, entryCount, ...name/time pairs` blocks, then the
- * flattened function rows preceded by their own length.
+ * Split the engine's per-frame array. Layout: the frame number, five timing
+ * fields, a server count, that many `name, entryCount, ...name/time pairs`
+ * blocks, then the flattened function rows preceded by their own length.
+ * Verified against `ServersProfilerFrame::serialize()`; `internal_time` at
+ * `i + 4` is deliberately skipped (the editor's "internal functions" toggle).
  */
 function parseFrame(data: Variant[], signatures: Map<number, string>): FrameSample {
   const timings: FrameTimings = {
@@ -213,9 +256,11 @@ function parseFrame(data: Variant[], signatures: Map<number, string>): FrameSamp
   };
   const servers: FrameSample['servers'] = [];
   let offset = 7;
-  for (let i = 0; i < asNumber(data[6]); i++) {
+  const serverCount = asCount(data[6], data.length);
+  for (let i = 0; i < serverCount; i++) {
     const name = data[offset];
-    const entries = asNumber(data[offset + 1]);
+    const entries = asCount(data[offset + 1], data.length - offset);
+    if (entries % 2 !== 0) throw badFrame('server block holds an odd entry count');
     const functions: Array<{ name: string; ms: number }> = [];
     for (let j = offset + 2; j < offset + 2 + entries; j += 2) {
       functions.push({ name: String(data[j]), ms: asNumber(data[j + 1]) * 1000 });
@@ -223,10 +268,10 @@ function parseFrame(data: Variant[], signatures: Map<number, string>): FrameSamp
     servers.push({ name: String(name), functions });
     offset += 2 + entries;
   }
-  const length = asNumber(data[offset]);
+  const length = asCount(data[offset], data.length - offset);
   offset += 1;
-  if (length < 0 || length % ROW_STRIDE !== 0 || offset + length !== data.length) {
-    throw new Error('Invalid profiler frame length');
+  if (length % ROW_STRIDE !== 0 || offset + length !== data.length) {
+    throw badFrame('row block does not fill the packet');
   }
   const rows: FrameRow[] = [];
   for (let i = offset; i < offset + length; i += ROW_STRIDE) {
@@ -247,12 +292,20 @@ function parseFrame(data: Variant[], signatures: Map<number, string>): FrameSamp
       totalMs: asNumber(data[i + 3]) * 1000,
     });
   }
-  return { frame: asNumber(data[0]), timings, servers, rows };
+  return {
+    frame: asNumber(data[0]),
+    timings,
+    servers,
+    rows,
+    rawRowCount: length / ROW_STRIDE,
+  };
 }
 
 export class DebuggerProfiler {
   private socket: net.Socket | null = null;
-  private rxBuffer: Buffer = Buffer.alloc(0);
+  /** Pending bytes, joined only once a whole frame has arrived (see `receive`). */
+  private rxChunks: Buffer[] = [];
+  private rxLength = 0;
   private threadId: Variant = null;
   private processId: number | null = null;
   private state: ProfilerState = 'idle';
@@ -260,6 +313,7 @@ export class DebuggerProfiler {
   private closed = false;
   private lastMessage: string | null = null;
   private lastDecodeError: string | null = null;
+  private undecodable = 0;
   private signatures: Map<number, string> = new Map();
   private capture: Capture | null = null;
   private autoStopTimer: NodeJS.Timeout | null = null;
@@ -291,9 +345,13 @@ export class DebuggerProfiler {
     });
   }
 
-  /** PID reported by the connected engine, or null before it connects. */
-  get pid(): number | null {
-    return this.processId;
+  /**
+   * A finished capture is readable even once the engine is gone — `stop` only
+   * re-ranks data already folded, and the capture worth reading is often the
+   * one taken right before a crash.
+   */
+  get hasResult(): boolean {
+    return this.capture?.result !== null && this.capture !== null;
   }
 
   get connected(): boolean {
@@ -332,11 +390,13 @@ export class DebuggerProfiler {
     this.signatures = new Map();
     this.capture = {
       limit: captureLimit,
+      maxSeconds: seconds,
       startedAt: Date.now(),
       elapsedMs: 0,
       frames: 0,
       framesReceived: 0,
       frameGaps: 0,
+      undecodablePackets: 0,
       firstFrame: null,
       lastFrame: null,
       capped: false,
@@ -350,11 +410,13 @@ export class DebuggerProfiler {
     };
     this.state = 'starting';
     this.send(true, captureLimit);
-    this.autoStopTimer = setTimeout(() => this.autoStop(), seconds * 1000);
 
     try {
+      // `result` satisfies this too: if the engine closes the capture before a
+      // frame is folded, that is an answer, not a reason to sit out the wait
+      // and then report a timeout for a capture the engine actually finished.
       await this.wait(
-        () => (this.capture?.frames ?? 0) > 0,
+        () => (this.capture?.frames ?? 0) > 0 || (this.capture?.result ?? null) !== null,
         WAIT_FIRST_FRAME_MS,
         'Godot sent no profiler frames',
       );
@@ -386,14 +448,42 @@ export class DebuggerProfiler {
       throw new ProfilerError('profile_not_started', 'Start a capture first');
     }
     this.autoStop();
-    const capture = this.capture;
-    await this.wait(() => capture.result !== null, WAIT_TOTAL_MS, 'Godot sent no profiler totals');
+    return this.finish(this.capture, top, sort);
+  }
+
+  /**
+   * Wait out a known capture's close and rank it. Takes the capture rather than
+   * re-reading `this.capture` so a caller that snapshotted one cannot be handed
+   * a different capture's numbers.
+   */
+  private async finish(capture: Capture, top: number, sort: ProfileSort): Promise<ProfileResult> {
+    try {
+      await this.wait(
+        () => capture.result !== null,
+        WAIT_TOTAL_MS,
+        'Godot sent no profiler totals',
+      );
+    } catch (err) {
+      // Close the capture out either way, so it never sits in `stopping` and
+      // stays re-readable. But only a timeout is recoverable here: the engine
+      // went quiet while the connection held, and what we folded is still
+      // good. A disconnect means the process died mid-capture, which the
+      // caller needs told — a later stop_profiler re-reads the partial data.
+      this.finalize(capture);
+      const recoverable = err instanceof ProfilerError && err.code === 'profile_timeout';
+      if (!recoverable || capture.frames === 0) throw err;
+    }
     return this.summarize(capture, top, sort);
   }
 
   /** `start` + wait out the window + `stop`, for a one-shot capture. */
-  async captureWindow(seconds: number, top: number, sort: ProfileSort): Promise<ProfileResult> {
-    await this.start(seconds, CAPTURE_LIMIT_MAX);
+  async captureWindow(
+    seconds: number,
+    top: number,
+    sort: ProfileSort,
+    captureLimit: number = CAPTURE_LIMIT_MAX,
+  ): Promise<ProfileResult> {
+    await this.start(seconds, captureLimit);
     const capture = this.capture;
     if (capture === null) throw new ProfilerError('profile_not_started', 'Capture was discarded');
     await this.wait(
@@ -401,7 +491,7 @@ export class DebuggerProfiler {
       seconds * 1000 + WAIT_TOTAL_MS,
       'Godot sent no profiler totals',
     );
-    return this.stop(top, sort);
+    return this.finish(capture, top, sort);
   }
 
   close(): void {
@@ -427,32 +517,69 @@ export class DebuggerProfiler {
     this.socket = socket;
     socket.on('data', (chunk: Buffer) => this.receive(chunk));
     socket.on('error', (err) => this.fail(err.message));
-    socket.on('close', () => this.fail('Debugger disconnected'));
+    socket.on('close', () => {
+      // Release the slot even when `fail` short-circuits on an earlier error,
+      // so `connected` stops claiming a peer that is gone.
+      if (this.socket === socket) this.socket = null;
+      this.fail('Debugger disconnected');
+    });
+  }
+
+  /** Read one pending byte without joining the chunk list. */
+  private byteAt(index: number): number {
+    let remaining = index;
+    for (const chunk of this.rxChunks) {
+      if (remaining < chunk.length) return chunk[remaining] as number;
+      remaining -= chunk.length;
+    }
+    throw new Error('Debugger read past the pending buffer');
   }
 
   private receive(chunk: Buffer): void {
-    this.rxBuffer = Buffer.concat([this.rxBuffer, chunk]);
-    while (this.rxBuffer.length >= 4) {
-      const size = this.rxBuffer.readUInt32LE(0);
-      if (size === 0 || size > MAX_PACKET_BYTES) {
-        this.fail('Debugger packet exceeds limit');
+    this.rxChunks.push(chunk);
+    this.rxLength += chunk.length;
+    while (this.rxLength >= 4) {
+      // Read the length prefix in place. Joining on every socket chunk would
+      // make assembling one large packet quadratic in its size.
+      const size =
+        this.byteAt(0) +
+        this.byteAt(1) * 0x100 +
+        this.byteAt(2) * 0x10000 +
+        this.byteAt(3) * 0x1000000;
+      if (size === 0) {
+        this.fail('Debugger sent a zero-length packet (framing desync)');
         return;
       }
-      if (this.rxBuffer.length < 4 + size) return;
-      const payload = this.rxBuffer.subarray(4, 4 + size);
-      this.rxBuffer = this.rxBuffer.subarray(4 + size);
+      if (size > MAX_PACKET_BYTES) {
+        this.fail(`Debugger packet of ${size} bytes exceeds the ${MAX_PACKET_BYTES}-byte limit`);
+        return;
+      }
+      if (this.rxLength < 4 + size) return;
+      const joined =
+        this.rxChunks.length === 1
+          ? (this.rxChunks[0] as Buffer)
+          : Buffer.concat(this.rxChunks, this.rxLength);
+      const payload = joined.subarray(4, 4 + size);
+      const rest = joined.subarray(4 + size);
+      this.rxChunks = rest.length > 0 ? [rest] : [];
+      this.rxLength = rest.length;
       let message: Variant;
       try {
         message = decodeVariant(payload);
       } catch (err) {
         // Unrelated debugger packets carry objects and vectors we don't decode.
         this.lastDecodeError = err instanceof Error ? err.message : String(err);
+        this.undecodable += 1;
+        if (this.capture !== null) this.capture.undecodablePackets += 1;
         continue;
       }
       try {
         this.handle(message);
       } catch (err) {
-        this.fail(err instanceof Error ? err.message : String(err));
+        // A frame we cannot parse is a stream we cannot trust, but it is not a
+        // dropped connection — report it as what it is.
+        const code = err instanceof ProfilerError ? err.code : 'profile_disconnected';
+        this.fail(err instanceof Error ? err.message : String(err), code);
         return;
       }
       this.notify();
@@ -491,23 +618,38 @@ export class DebuggerProfiler {
     const capture = this.capture;
     const sample = parseFrame(data, this.signatures);
     const rows = sample.rows;
-    capture.capped = capture.capped || rows.length >= capture.limit;
 
     if (name === 'servers:profile_total') {
-      capture.result = [...capture.totals.values()];
-      capture.elapsedMs = Date.now() - capture.startedAt;
-      this.state = 'finished';
-      this.clearAutoStop();
+      // The engine's own accumulated rows are capped by `captureLimit` exactly
+      // as the frame packets are, and carry nothing the frames did not already
+      // deliver — while top-N membership rotates between frames, so summing
+      // them covers strictly more functions. Verified against Godot: at a limit
+      // of 16 the frames saw 37 distinct functions and this packet only 16, and
+      // its call counts match our sums exactly. So this is a completion
+      // sentinel, not the source of the totals.
+      this.finalize(capture);
       return;
     }
     if (this.state === 'starting') this.state = 'capturing';
     capture.framesReceived += 1;
     // Enabling the profiler inside a running VM call gives that first sample a
-    // zero start timestamp, so its elapsed time is fiction. Drop it.
+    // zero start timestamp, so its elapsed time is fiction. Drop it — and with
+    // it any truncation it reported, which describes numbers we discarded.
     if (capture.framesReceived === 1) return;
+
+    // The engine fills each frame packet up to `captureLimit` rows, chosen by
+    // inclusive time, before we drop the zero-call ones — so the raw count is
+    // what says whether this frame was truncated.
+    capture.capped = capture.capped || sample.rawRowCount >= capture.limit;
 
     const frame = sample.frame;
     capture.frames += 1;
+    if (capture.frames === 1) {
+      // Measure the window from real data, not from the enable round trip: the
+      // handshake and first-frame latency are not time the game was profiled.
+      capture.startedAt = Date.now();
+      this.armAutoStop();
+    }
     if (capture.firstFrame === null) capture.firstFrame = frame;
     if (capture.lastFrame !== null) {
       capture.frameGaps += Math.max(0, frame - capture.lastFrame - 1);
@@ -558,7 +700,17 @@ export class DebuggerProfiler {
   }
 
   private summarize(capture: Capture, top: number, sort: ProfileSort): ProfileResult {
-    const frames = Math.max(1, capture.frames);
+    if (capture.frames === 0) {
+      // Dividing by a synthetic 1 here would return a well-formed payload of
+      // zeroes and an empty `rows`, which reads exactly like "nothing in this
+      // game is slow" rather than "nothing was measured".
+      throw new ProfilerError(
+        'profile_no_frames',
+        `The capture folded no usable frames (received ${capture.framesReceived}; the first is ` +
+          `always discarded), so there is nothing to rank`,
+      );
+    }
+    const frames = capture.frames;
     const frame = {} as Record<keyof FrameTimings, ProfileStat>;
     for (const key of Object.keys(capture.timingSums) as Array<keyof FrameTimings>) {
       frame[key] = { avg: capture.timingSums[key] / frames, max: capture.timingMax[key] };
@@ -598,6 +750,7 @@ export class DebuggerProfiler {
       firstFrame: capture.firstFrame,
       lastFrame: capture.lastFrame,
       frameGaps: capture.frameGaps,
+      undecodablePackets: capture.undecodablePackets,
       captureLimit: capture.limit,
       limitReached: capture.capped,
       sort,
@@ -640,17 +793,46 @@ export class DebuggerProfiler {
     this.notify();
   }
 
+  private armAutoStop(): void {
+    this.clearAutoStop();
+    const seconds = this.capture?.maxSeconds ?? PROFILE_MAX_SECONDS;
+    this.autoStopTimer = setTimeout(() => this.autoStop(), seconds * 1000);
+  }
+
   private clearAutoStop(): void {
     if (this.autoStopTimer === null) return;
     clearTimeout(this.autoStopTimer);
     this.autoStopTimer = null;
   }
 
-  private fail(reason: string): void {
-    if (this.error !== null) return;
+  /**
+   * Close a capture out. Called on the engine's `profile_total`, and again if
+   * that packet never arrives — a capture left in `stopping` would reject every
+   * later `start` as busy while `stop` kept timing out, and the advice on that
+   * error points straight back at `stop`.
+   */
+  private finalize(capture: Capture): void {
+    if (capture.result === null) {
+      capture.result = [...capture.totals.values()];
+      capture.elapsedMs = Date.now() - capture.startedAt;
+    }
+    this.state = 'finished';
+    this.clearAutoStop();
+  }
+
+  private fail(reason: string, code: ProfilerErrorCode = 'profile_disconnected'): void {
+    // A clean teardown destroys the socket, which fires `close` — that is not a
+    // disconnect worth reporting or logging.
+    if (this.error !== null || this.closed) return;
     this.error = reason;
     logDebug(`[Profiler] ${reason}`);
-    this.rejectWaiters(new ProfilerError('profile_disconnected', reason));
+    // Stop reading: leaving the socket subscribed after a framing error means
+    // the bad header stays at offset 0 and the pending buffer never drains.
+    this.socket?.destroy();
+    this.socket = null;
+    this.rxChunks = [];
+    this.rxLength = 0;
+    this.rejectWaiters(new ProfilerError(code, reason));
   }
 
   // --- waiting ---

--- a/src/utils/profiler.ts
+++ b/src/utils/profiler.ts
@@ -1,0 +1,702 @@
+/**
+ * Receiver for Godot's own remote-debugger profiler stream.
+ *
+ * `run_project({ profiling: true })` binds this listener first and passes
+ * `--remote-debug tcp://127.0.0.1:<port>` to the spawned engine, so the
+ * measurements are the stock editor ones — no engine build, no addon, and
+ * nothing injected into the project. Attached sessions cannot profile: the
+ * debugger channel only exists if it was on the command line at launch.
+ *
+ * Godot pauses the game on a script error or `breakpoint` while a debugger is
+ * connected, so every `debug_enter` is answered with `continue` — profiling
+ * must never turn a runtime error into a frozen window.
+ */
+
+import * as net from 'net';
+import { decodeVariant, encodeVariant, MAX_PACKET_BYTES, type Variant } from './godot-variant.js';
+import { logDebug } from './logger.js';
+
+export type ProfilerErrorCode =
+  | 'bad_args'
+  | 'profile_busy'
+  | 'profile_not_started'
+  | 'profile_timeout'
+  | 'profile_disconnected';
+
+export class ProfilerError extends Error {
+  constructor(
+    readonly code: ProfilerErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ProfilerError';
+  }
+}
+
+export type ProfileSort = 'selfMs' | 'totalMs' | 'calls';
+
+export const PROFILE_SORTS: readonly ProfileSort[] = ['selfMs', 'totalMs', 'calls'];
+export const PROFILE_MAX_SECONDS = 60;
+export const CAPTURE_LIMIT_MIN = 16;
+export const CAPTURE_LIMIT_MAX = 512;
+export const PROFILE_TOP_MAX = 100;
+
+/** Bound on the rows kept for the slowest frame — a full frame is unbounded. */
+const WORST_FRAME_ROWS = 30;
+/** Every engine row is `[signature id, calls, self, total, internal]`. */
+const ROW_STRIDE = 5;
+
+const WAIT_CONNECT_MS = 5000;
+const WAIT_FIRST_FRAME_MS = 5000;
+const WAIT_TOTAL_MS = 10000;
+
+export interface ProfilePeak {
+  frame: number;
+  calls: number;
+  selfMs: number;
+  totalMs: number;
+}
+
+export interface ProfileRow {
+  signature: string;
+  function: string;
+  file: string;
+  line: number;
+  sourceResolved: boolean;
+  calls: number;
+  selfMs: number;
+  totalMs: number;
+  callsPerFrame: number;
+  selfMsPerFrame: number;
+  totalMsPerFrame: number;
+  msPerCall: number;
+  /** Inclusive share of an average frame, the editor's "Frame %" measure. */
+  percentOfFrame: number;
+  peak: ProfilePeak | null;
+}
+
+/** Average and worst value of one per-frame measurement across the capture. */
+export interface ProfileStat {
+  avg: number;
+  max: number;
+}
+
+/** The engine's own frame breakdown — the editor's "Frame Time" category. */
+export interface FrameTimings {
+  frameMs: number;
+  processMs: number;
+  physicsMs: number;
+  physicsFrameMs: number;
+  scriptMs: number;
+}
+
+export interface ProfileServer {
+  name: string;
+  msPerFrame: number;
+  functions: Array<{ name: string; msPerFrame: number }>;
+}
+
+export interface ProfileStartResult {
+  active: boolean;
+  maxSeconds: number;
+  firstFrame: number | null;
+  captureLimit: number;
+}
+
+export interface ProfileResult {
+  seconds: number;
+  frames: number;
+  framesReceived: number;
+  firstFrame: number | null;
+  lastFrame: number | null;
+  frameGaps: number;
+  captureLimit: number;
+  limitReached: boolean;
+  sort: ProfileSort;
+  functionsReceived: number;
+  unresolvedFunctions: number;
+  /** Per-frame engine breakdown, averaged over the capture and at its worst. */
+  frame: Record<keyof FrameTimings, ProfileStat>;
+  /** Server-side timings (physics, audio, …), averaged per frame. */
+  servers: ProfileServer[];
+  rows: ProfileRow[];
+  worstFrame: ({ frame: number } & FrameTimings & { rows: FrameRow[] }) | null;
+}
+
+/** One function's numbers inside a single received frame. */
+interface FrameRow {
+  signature: string;
+  function: string;
+  file: string;
+  line: number;
+  sourceResolved: boolean;
+  calls: number;
+  selfMs: number;
+  totalMs: number;
+}
+
+interface Capture {
+  limit: number;
+  startedAt: number;
+  elapsedMs: number;
+  /** Frames folded into the totals (excludes the discarded boundary frame). */
+  frames: number;
+  framesReceived: number;
+  frameGaps: number;
+  firstFrame: number | null;
+  lastFrame: number | null;
+  capped: boolean;
+  totals: Map<string, FrameRow>;
+  peaks: Map<string, ProfilePeak>;
+  timingSums: FrameTimings;
+  timingMax: FrameTimings;
+  /** server name → function name → summed milliseconds. */
+  servers: Map<string, Map<string, number>>;
+  worst: ({ frame: number } & FrameTimings & { rows: FrameRow[] }) | null;
+  result: FrameRow[] | null;
+}
+
+type ProfilerState = 'idle' | 'starting' | 'capturing' | 'stopping' | 'finished';
+
+interface Waiter {
+  predicate: () => boolean;
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+function asNumber(value: Variant | undefined): number {
+  if (typeof value !== 'number') throw new Error('Expected a number in a profiler frame');
+  return value;
+}
+
+/** Trim float noise from the summary — these are milliseconds, not physics. */
+function roundNumbers<T>(value: T): T {
+  if (typeof value === 'number') return (Math.round(value * 1e4) / 1e4) as T;
+  if (Array.isArray(value)) return value.map(roundNumbers) as T;
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, inner]) => [key, roundNumbers(inner)]),
+    ) as T;
+  }
+  return value;
+}
+
+const noTimings = (): FrameTimings => ({
+  frameMs: 0,
+  processMs: 0,
+  physicsMs: 0,
+  physicsFrameMs: 0,
+  scriptMs: 0,
+});
+
+/** One received frame, in the same three parts the editor's tree shows. */
+interface FrameSample {
+  frame: number;
+  timings: FrameTimings;
+  servers: Array<{ name: string; functions: Array<{ name: string; ms: number }> }>;
+  rows: FrameRow[];
+}
+
+/**
+ * Split the engine's per-frame array. Layout: six timing fields, a server
+ * count, that many `name, entryCount, ...name/time pairs` blocks, then the
+ * flattened function rows preceded by their own length.
+ */
+function parseFrame(data: Variant[], signatures: Map<number, string>): FrameSample {
+  const timings: FrameTimings = {
+    frameMs: asNumber(data[1]) * 1000,
+    processMs: asNumber(data[2]) * 1000,
+    physicsMs: asNumber(data[3]) * 1000,
+    physicsFrameMs: asNumber(data[4]) * 1000,
+    scriptMs: asNumber(data[5]) * 1000,
+  };
+  const servers: FrameSample['servers'] = [];
+  let offset = 7;
+  for (let i = 0; i < asNumber(data[6]); i++) {
+    const name = data[offset];
+    const entries = asNumber(data[offset + 1]);
+    const functions: Array<{ name: string; ms: number }> = [];
+    for (let j = offset + 2; j < offset + 2 + entries; j += 2) {
+      functions.push({ name: String(data[j]), ms: asNumber(data[j + 1]) * 1000 });
+    }
+    servers.push({ name: String(name), functions });
+    offset += 2 + entries;
+  }
+  const length = asNumber(data[offset]);
+  offset += 1;
+  if (length < 0 || length % ROW_STRIDE !== 0 || offset + length !== data.length) {
+    throw new Error('Invalid profiler frame length');
+  }
+  const rows: FrameRow[] = [];
+  for (let i = offset; i < offset + length; i += ROW_STRIDE) {
+    const calls = asNumber(data[i + 1]);
+    if (calls === 0) continue;
+    const id = asNumber(data[i]);
+    const resolved = signatures.get(id);
+    const signature = resolved ?? `<unresolved:${id}>`;
+    const parts = signature.split('::');
+    rows.push({
+      signature,
+      file: parts.length >= 3 ? parts.slice(0, -2).join('::') : (parts[0] ?? ''),
+      line: parts.length >= 3 ? Number(parts[parts.length - 2]) : 0,
+      function: parts[parts.length - 1] ?? signature,
+      sourceResolved: resolved !== undefined,
+      calls,
+      selfMs: asNumber(data[i + 2]) * 1000,
+      totalMs: asNumber(data[i + 3]) * 1000,
+    });
+  }
+  return { frame: asNumber(data[0]), timings, servers, rows };
+}
+
+export class DebuggerProfiler {
+  private socket: net.Socket | null = null;
+  private rxBuffer: Buffer = Buffer.alloc(0);
+  private threadId: Variant = null;
+  private processId: number | null = null;
+  private state: ProfilerState = 'idle';
+  private error: string | null = null;
+  private closed = false;
+  private lastMessage: string | null = null;
+  private lastDecodeError: string | null = null;
+  private signatures: Map<number, string> = new Map();
+  private capture: Capture | null = null;
+  private autoStopTimer: NodeJS.Timeout | null = null;
+  private waiters: Waiter[] = [];
+
+  private constructor(
+    private readonly server: net.Server,
+    readonly port: number,
+  ) {
+    server.on('connection', (socket) => this.accept(socket));
+    server.on('error', (err) => this.fail(err.message));
+  }
+
+  /** Bind a loopback listener the spawned engine will dial back into. */
+  static create(): Promise<DebuggerProfiler> {
+    return new Promise((resolve, reject) => {
+      const server = net.createServer();
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        if (address === null || typeof address === 'string') {
+          server.close();
+          reject(new Error('Failed to bind a debugger port for profiling'));
+          return;
+        }
+        server.removeListener('error', reject);
+        resolve(new DebuggerProfiler(server, address.port));
+      });
+    });
+  }
+
+  /** PID reported by the connected engine, or null before it connects. */
+  get pid(): number | null {
+    return this.processId;
+  }
+
+  get connected(): boolean {
+    return this.socket !== null && this.threadId !== null;
+  }
+
+  /**
+   * Enable the engine profiler and return once frames are arriving. The
+   * capture stops itself after `seconds` so a forgotten `start_profiler`
+   * cannot profile the rest of the session.
+   */
+  async start(seconds: number, captureLimit: number): Promise<ProfileStartResult> {
+    if (!Number.isFinite(seconds) || seconds <= 0 || seconds > PROFILE_MAX_SECONDS) {
+      throw new ProfilerError('bad_args', `seconds must be in (0, ${PROFILE_MAX_SECONDS}]`);
+    }
+    if (
+      !Number.isInteger(captureLimit) ||
+      captureLimit < CAPTURE_LIMIT_MIN ||
+      captureLimit > CAPTURE_LIMIT_MAX
+    ) {
+      throw new ProfilerError(
+        'bad_args',
+        `captureLimit must be an integer in [${CAPTURE_LIMIT_MIN}, ${CAPTURE_LIMIT_MAX}]`,
+      );
+    }
+    if (this.state === 'starting' || this.state === 'capturing' || this.state === 'stopping') {
+      throw new ProfilerError('profile_busy', 'A capture is already active');
+    }
+
+    await this.wait(
+      () => this.threadId !== null,
+      WAIT_CONNECT_MS,
+      'Godot never opened the debugger connection',
+    );
+
+    this.signatures = new Map();
+    this.capture = {
+      limit: captureLimit,
+      startedAt: Date.now(),
+      elapsedMs: 0,
+      frames: 0,
+      framesReceived: 0,
+      frameGaps: 0,
+      firstFrame: null,
+      lastFrame: null,
+      capped: false,
+      totals: new Map(),
+      peaks: new Map(),
+      timingSums: noTimings(),
+      timingMax: noTimings(),
+      servers: new Map(),
+      worst: null,
+      result: null,
+    };
+    this.state = 'starting';
+    this.send(true, captureLimit);
+    this.autoStopTimer = setTimeout(() => this.autoStop(), seconds * 1000);
+
+    try {
+      await this.wait(
+        () => (this.capture?.frames ?? 0) > 0,
+        WAIT_FIRST_FRAME_MS,
+        'Godot sent no profiler frames',
+      );
+    } catch (err) {
+      this.autoStop();
+      throw err;
+    }
+    return {
+      active: this.isCapturing(),
+      maxSeconds: seconds,
+      firstFrame: this.capture.firstFrame,
+      captureLimit: captureLimit,
+    };
+  }
+
+  /**
+   * Stop an active capture (or re-read a finished one) and rank the functions.
+   * The engine's own accumulated totals close the capture, so this waits for
+   * the `profile_total` packet rather than summing the last frame.
+   */
+  async stop(top: number, sort: ProfileSort): Promise<ProfileResult> {
+    if (!Number.isInteger(top) || top < 1 || top > PROFILE_TOP_MAX) {
+      throw new ProfilerError('bad_args', `top must be an integer in [1, ${PROFILE_TOP_MAX}]`);
+    }
+    if (!PROFILE_SORTS.includes(sort)) {
+      throw new ProfilerError('bad_args', `sort must be one of ${PROFILE_SORTS.join(', ')}`);
+    }
+    if (this.state === 'idle' || this.capture === null) {
+      throw new ProfilerError('profile_not_started', 'Start a capture first');
+    }
+    this.autoStop();
+    const capture = this.capture;
+    await this.wait(() => capture.result !== null, WAIT_TOTAL_MS, 'Godot sent no profiler totals');
+    return this.summarize(capture, top, sort);
+  }
+
+  /** `start` + wait out the window + `stop`, for a one-shot capture. */
+  async captureWindow(seconds: number, top: number, sort: ProfileSort): Promise<ProfileResult> {
+    await this.start(seconds, CAPTURE_LIMIT_MAX);
+    const capture = this.capture;
+    if (capture === null) throw new ProfilerError('profile_not_started', 'Capture was discarded');
+    await this.wait(
+      () => capture.result !== null,
+      seconds * 1000 + WAIT_TOTAL_MS,
+      'Godot sent no profiler totals',
+    );
+    return this.stop(top, sort);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.state === 'starting' || this.state === 'capturing') {
+      this.autoStop();
+    }
+    this.clearAutoStop();
+    this.rejectWaiters(new ProfilerError('profile_disconnected', 'Profiler closed'));
+    this.socket?.destroy();
+    this.socket = null;
+    this.server.close();
+  }
+
+  // --- transport ---
+
+  private accept(socket: net.Socket): void {
+    if (this.socket !== null || this.closed) {
+      socket.destroy();
+      return;
+    }
+    this.socket = socket;
+    socket.on('data', (chunk: Buffer) => this.receive(chunk));
+    socket.on('error', (err) => this.fail(err.message));
+    socket.on('close', () => this.fail('Debugger disconnected'));
+  }
+
+  private receive(chunk: Buffer): void {
+    this.rxBuffer = Buffer.concat([this.rxBuffer, chunk]);
+    while (this.rxBuffer.length >= 4) {
+      const size = this.rxBuffer.readUInt32LE(0);
+      if (size === 0 || size > MAX_PACKET_BYTES) {
+        this.fail('Debugger packet exceeds limit');
+        return;
+      }
+      if (this.rxBuffer.length < 4 + size) return;
+      const payload = this.rxBuffer.subarray(4, 4 + size);
+      this.rxBuffer = this.rxBuffer.subarray(4 + size);
+      let message: Variant;
+      try {
+        message = decodeVariant(payload);
+      } catch (err) {
+        // Unrelated debugger packets carry objects and vectors we don't decode.
+        this.lastDecodeError = err instanceof Error ? err.message : String(err);
+        continue;
+      }
+      try {
+        this.handle(message);
+      } catch (err) {
+        this.fail(err instanceof Error ? err.message : String(err));
+        return;
+      }
+      this.notify();
+    }
+  }
+
+  private handle(message: Variant): void {
+    if (!Array.isArray(message) || message.length !== 3) return;
+    const [name, data] = [message[0], message[2]];
+    const threadId = message[1] ?? null;
+    if (typeof name !== 'string' || !Array.isArray(data)) return;
+    this.lastMessage = name;
+
+    if (name === 'set_pid') {
+      this.threadId = threadId;
+      this.processId = typeof data[0] === 'number' ? data[0] : null;
+      return;
+    }
+    if (name === 'debug_enter') {
+      // A script error or `breakpoint` halted the game; resume it immediately.
+      this.write(['continue', threadId, []]);
+      return;
+    }
+    const capturing =
+      this.state === 'starting' || this.state === 'capturing' || this.state === 'stopping';
+    if (!capturing || this.capture === null) return;
+
+    if (name === 'servers:function_signature') {
+      if (typeof data[0] === 'string' && typeof data[1] === 'number') {
+        this.signatures.set(data[1], data[0]);
+      }
+      return;
+    }
+    if (name !== 'servers:profile_frame' && name !== 'servers:profile_total') return;
+
+    const capture = this.capture;
+    const sample = parseFrame(data, this.signatures);
+    const rows = sample.rows;
+    capture.capped = capture.capped || rows.length >= capture.limit;
+
+    if (name === 'servers:profile_total') {
+      capture.result = [...capture.totals.values()];
+      capture.elapsedMs = Date.now() - capture.startedAt;
+      this.state = 'finished';
+      this.clearAutoStop();
+      return;
+    }
+    if (this.state === 'starting') this.state = 'capturing';
+    capture.framesReceived += 1;
+    // Enabling the profiler inside a running VM call gives that first sample a
+    // zero start timestamp, so its elapsed time is fiction. Drop it.
+    if (capture.framesReceived === 1) return;
+
+    const frame = sample.frame;
+    capture.frames += 1;
+    if (capture.firstFrame === null) capture.firstFrame = frame;
+    if (capture.lastFrame !== null) {
+      capture.frameGaps += Math.max(0, frame - capture.lastFrame - 1);
+    }
+    capture.lastFrame = frame;
+
+    for (const key of Object.keys(capture.timingSums) as Array<keyof FrameTimings>) {
+      capture.timingSums[key] += sample.timings[key];
+      capture.timingMax[key] = Math.max(capture.timingMax[key], sample.timings[key]);
+    }
+    for (const server of sample.servers) {
+      let functions = capture.servers.get(server.name);
+      if (functions === undefined) {
+        functions = new Map();
+        capture.servers.set(server.name, functions);
+      }
+      for (const fn of server.functions) {
+        functions.set(fn.name, (functions.get(fn.name) ?? 0) + fn.ms);
+      }
+    }
+
+    for (const row of rows) {
+      const total = capture.totals.get(row.signature);
+      if (total === undefined) {
+        capture.totals.set(row.signature, { ...row });
+      } else {
+        total.calls += row.calls;
+        total.selfMs += row.selfMs;
+        total.totalMs += row.totalMs;
+      }
+      const peak = capture.peaks.get(row.signature);
+      if (peak === undefined || row.totalMs > peak.totalMs) {
+        capture.peaks.set(row.signature, {
+          frame,
+          calls: row.calls,
+          selfMs: row.selfMs,
+          totalMs: row.totalMs,
+        });
+      }
+    }
+    if (capture.worst === null || sample.timings.frameMs > capture.worst.frameMs) {
+      capture.worst = {
+        frame,
+        ...sample.timings,
+        rows: [...rows].sort((a, b) => b.totalMs - a.totalMs).slice(0, WORST_FRAME_ROWS),
+      };
+    }
+  }
+
+  private summarize(capture: Capture, top: number, sort: ProfileSort): ProfileResult {
+    const frames = Math.max(1, capture.frames);
+    const frame = {} as Record<keyof FrameTimings, ProfileStat>;
+    for (const key of Object.keys(capture.timingSums) as Array<keyof FrameTimings>) {
+      frame[key] = { avg: capture.timingSums[key] / frames, max: capture.timingMax[key] };
+    }
+    const servers: ProfileServer[] = [];
+    for (const [name, functions] of capture.servers) {
+      const entries = [...functions.entries()]
+        .map(([fn, ms]) => ({ name: fn, msPerFrame: ms / frames }))
+        .sort((a, b) => b.msPerFrame - a.msPerFrame);
+      servers.push({
+        name,
+        msPerFrame: entries.reduce((sum, fn) => sum + fn.msPerFrame, 0),
+        functions: entries,
+      });
+    }
+    servers.sort((a, b) => b.msPerFrame - a.msPerFrame);
+
+    const rows: ProfileRow[] = [];
+    for (const row of capture.result ?? []) {
+      if (row.calls <= 0) continue;
+      const totalMsPerFrame = row.totalMs / frames;
+      rows.push({
+        ...row,
+        callsPerFrame: row.calls / frames,
+        selfMsPerFrame: row.selfMs / frames,
+        totalMsPerFrame,
+        msPerCall: row.totalMs / row.calls,
+        percentOfFrame: frame.frameMs.avg > 0 ? (totalMsPerFrame / frame.frameMs.avg) * 100 : 0,
+        peak: capture.peaks.get(row.signature) ?? null,
+      });
+    }
+    rows.sort((a, b) => b[sort] - a[sort]);
+    return roundNumbers({
+      seconds: capture.elapsedMs / 1000,
+      frames: capture.frames,
+      framesReceived: capture.framesReceived,
+      firstFrame: capture.firstFrame,
+      lastFrame: capture.lastFrame,
+      frameGaps: capture.frameGaps,
+      captureLimit: capture.limit,
+      limitReached: capture.capped,
+      sort,
+      functionsReceived: rows.length,
+      unresolvedFunctions: rows.filter((r) => !r.sourceResolved).length,
+      frame,
+      servers,
+      rows: rows.slice(0, top),
+      worstFrame: capture.worst,
+    });
+  }
+
+  /** Read behind a call so `start`'s own state assignment doesn't narrow it. */
+  private isCapturing(): boolean {
+    return this.state === 'capturing';
+  }
+
+  private send(enabled: boolean, limit: number): void {
+    this.write(['profiler:servers', this.threadId, enabled ? [true, [limit, false]] : [false]]);
+  }
+
+  private write(message: Variant): void {
+    const socket = this.socket;
+    if (socket === null) return;
+    const raw = encodeVariant(message);
+    const header = Buffer.alloc(4);
+    header.writeUInt32LE(raw.length, 0);
+    try {
+      socket.write(Buffer.concat([header, raw]));
+    } catch (err) {
+      this.fail(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  private autoStop(): void {
+    if (this.state !== 'starting' && this.state !== 'capturing') return;
+    this.state = 'stopping';
+    this.clearAutoStop();
+    if (this.capture) this.send(false, this.capture.limit);
+    this.notify();
+  }
+
+  private clearAutoStop(): void {
+    if (this.autoStopTimer === null) return;
+    clearTimeout(this.autoStopTimer);
+    this.autoStopTimer = null;
+  }
+
+  private fail(reason: string): void {
+    if (this.error !== null) return;
+    this.error = reason;
+    logDebug(`[Profiler] ${reason}`);
+    this.rejectWaiters(new ProfilerError('profile_disconnected', reason));
+  }
+
+  // --- waiting ---
+
+  private wait(predicate: () => boolean, timeoutMs: number, what: string): Promise<void> {
+    if (predicate()) return Promise.resolve();
+    if (this.error !== null || this.closed) {
+      return Promise.reject(
+        new ProfilerError('profile_disconnected', this.error ?? 'Profiler closed'),
+      );
+    }
+    return new Promise<void>((resolve, reject) => {
+      const waiter: Waiter = {
+        predicate,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.waiters = this.waiters.filter((w) => w !== waiter);
+          reject(
+            new ProfilerError(
+              'profile_timeout',
+              `${what} (last debugger message: ${this.lastMessage ?? 'none'}; ` +
+                `signatures: ${this.signatures.size}; decode: ${this.lastDecodeError ?? 'none'})`,
+            ),
+          );
+        }, timeoutMs),
+      };
+      this.waiters.push(waiter);
+    });
+  }
+
+  private notify(): void {
+    for (const waiter of [...this.waiters]) {
+      if (!waiter.predicate()) continue;
+      this.waiters = this.waiters.filter((w) => w !== waiter);
+      clearTimeout(waiter.timer);
+      waiter.resolve();
+    }
+  }
+
+  private rejectWaiters(error: ProfilerError): void {
+    const waiters = this.waiters;
+    this.waiters = [];
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,7 +10,8 @@ tests/
 ├── integration/      Tests that touch fixtures or run real Godot.
 │                     Godot-required tests skip when GODOT_PATH is unset.
 ├── fixtures/         Committed test inputs.
-│   └── godot-project/  Minimal Godot 4 project (Node2D + Label + Sprite2D)
+│   ├── godot-project/  Minimal Godot 4 project (Node2D + Label + Sprite2D)
+│   └── godot-profiling-project/  Same, with a hot _process loop for the profiler tests
 └── README.md         This file.
 ```
 
@@ -31,6 +32,10 @@ tests/
 | `integration/runner-executeOperation.test.ts` | `executeOperation` for `validate_resource` (scene + broken GDScript); `handleGetProjectInfo`                             | Requires `GODOT_PATH`                                   |
 | `integration/scene-roundtrip.test.ts`         | `add_node` / `set_node_properties` / `delete_nodes` round-trip + auto-save invariant (all 3 operations)                  | Requires `GODOT_PATH`; tmp fixture copy                 |
 | `integration/runtime-smoke.test.ts`           | `run_project` → `take_screenshot` smoke test; skips gracefully if no display server                                      | Requires `GODOT_PATH`; may skip headless                |
+| `unit/godot-variant.test.ts`                  | Variant encode/decode round-trip and malformed-packet rejection                                                          |                                                         |
+| `unit/profiler.test.ts`                       | `DebuggerProfiler` against a fake Godot debugger peer: frame aggregation, auto-stop, break-continue, error codes         |                                                         |
+| `unit/handlers/profiler-handlers.test.ts`     | Argument defaults, sort enum, and ProfilerError mapping in `src/tools/profiler-tools.ts`                                 |                                                         |
+| `integration/profiler-smoke.test.ts`          | `run_project({ profiling: true })` → `profile_project` / `start_profiler` + `stop_profiler` against a real engine        | Requires `GODOT_PATH`; needs a display server           |
 | `integration/fixture.test.ts`                 | Smoke check that `tests/fixtures/godot-project/` is well-formed                                                          | No Godot required                                       |
 
 (Add new rows here as additional test files land.)

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -9,6 +9,12 @@ Contents:
 - `main.tscn` — `Node2D` root with `Label` and `Sprite2D` children
 - `placeholder.gd`, `placeholder.png` — empty placeholder files used by handler tests that exercise `attach_script` / `load_sprite` runner-throws paths
 
+## `godot-profiling-project/`
+
+The same shape, with a `_process` loop that burns measurable time (`hot_loop.gd::burn`).
+`integration/profiler-smoke.test.ts` launches it with `profiling: true` and expects that
+function to come back at the top of the capture. Import it as `profilingFixtureProjectPath`.
+
 Use it from tests by importing the path helper:
 
 ```ts

--- a/tests/fixtures/godot-profiling-project/hot_loop.gd
+++ b/tests/fixtures/godot-profiling-project/hot_loop.gd
@@ -1,0 +1,12 @@
+extends Node2D
+
+# Deliberately expensive per frame so `burn` dominates any profiler capture.
+func _process(_delta: float) -> void:
+	burn(20000)
+
+
+func burn(iterations: int) -> float:
+	var total := 0.0
+	for i in iterations:
+		total += sqrt(float(i))
+	return total

--- a/tests/fixtures/godot-profiling-project/main.tscn
+++ b/tests/fixtures/godot-profiling-project/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://hot_loop.gd" id="1"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1")

--- a/tests/fixtures/godot-profiling-project/project.godot
+++ b/tests/fixtures/godot-profiling-project/project.godot
@@ -1,0 +1,17 @@
+; Engine configuration file.
+; Godot 4 fixture whose main scene burns measurable time in _process, so the
+; profiler tests have a function they can expect to see ranked.
+; See tests/fixtures/README.md for usage.
+
+config_version=5
+
+[application]
+
+config/name="godot-mcp-runtime profiling fixture"
+run/main_scene="res://main.tscn"
+config/features=PackedStringArray("4.4")
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"

--- a/tests/helpers/fixture-paths.ts
+++ b/tests/helpers/fixture-paths.ts
@@ -13,6 +13,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 /** Absolute path to tests/fixtures/godot-project. */
 export const fixtureProjectPath = join(here, '..', 'fixtures', 'godot-project');
 
+/** Absolute path to tests/fixtures/godot-profiling-project (hot _process loop). */
+export const profilingFixtureProjectPath = join(here, '..', 'fixtures', 'godot-profiling-project');
+
 /** Scene path *relative to the project root* — matches the MCP tool contract. */
 export const fixtureScenePath = 'main.tscn';
 

--- a/tests/integration/profiler-smoke.test.ts
+++ b/tests/integration/profiler-smoke.test.ts
@@ -1,0 +1,146 @@
+/**
+ * End-to-end profiling against a real engine: `run_project({ profiling: true })`
+ * has to bind the debugger port, survive Godot's own `--remote-debug` handshake,
+ * and come back with the fixture's hot function ranked at the top.
+ *
+ * The frame layout the receiver parses is the engine's, not ours, so this is
+ * the only test that can catch a layout change in a future Godot release.
+ *
+ * Requires GODOT_PATH and a display server. Skipped in CI.
+ */
+
+import { describe, beforeAll, afterEach, expect } from 'vitest';
+import { join } from 'path';
+import { cpSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import { itGodot } from '../helpers/godot-skip.js';
+import { profilingFixtureProjectPath } from '../helpers/fixture-paths.js';
+import { GodotRunner } from '../../src/utils/godot-runner.js';
+import {
+  handleProfileProject,
+  handleStartProfiler,
+  handleStopProfiler,
+} from '../../src/tools/profiler-tools.js';
+import { hasError, unwrap } from '../helpers/assertions.js';
+
+interface CaptureShape {
+  frames: number;
+  frame: Record<'frameMs' | 'processMs' | 'scriptMs', { avg: number; max: number }>;
+  servers: Array<{ name: string; msPerFrame: number; functions: Array<{ name: string }> }>;
+  worstFrame: { frame: number; frameMs: number; scriptMs: number };
+  rows: Array<{
+    function: string;
+    file: string;
+    line: number;
+    calls: number;
+    selfMs: number;
+    percentOfFrame: number;
+  }>;
+}
+
+function isHeadlessEnvironmentError(err: string | undefined): boolean {
+  if (!err) return false;
+  const lower = err.toLowerCase();
+  return lower.includes('display') || lower.includes('wayland') || lower.includes('x server');
+}
+
+describe('profiler smoke', () => {
+  let runner: GodotRunner;
+  let tmpProject: string | null = null;
+
+  beforeAll(async () => {
+    runner = new GodotRunner({ godotPath: process.env.GODOT_PATH });
+    await runner.detectGodotPath();
+  });
+
+  afterEach(async () => {
+    try {
+      await runner.stopProject();
+    } catch {
+      // already stopped
+    }
+    if (tmpProject) {
+      try {
+        rmSync(tmpProject, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+      tmpProject = null;
+    }
+  });
+
+  async function launchProfilingSession(ctx: { skip: (reason: string) => void }): Promise<void> {
+    const id = randomBytes(6).toString('hex');
+    tmpProject = join(tmpdir(), `godot-mcp-profiling-${id}`);
+    cpSync(profilingFixtureProjectPath, tmpProject, { recursive: true });
+
+    await runner.runProject(tmpProject, undefined, false, undefined, true);
+    const bridgeResult = await runner.waitForBridge(20000);
+    if (!bridgeResult.ready) {
+      if (isHeadlessEnvironmentError(bridgeResult.error)) {
+        ctx.skip(`display server unavailable (${bridgeResult.error})`);
+      }
+      throw new Error(`Bridge failed to initialise: ${bridgeResult.error ?? 'unknown error'}`);
+    }
+    expect(runner.activeProfiler).not.toBeNull();
+  }
+
+  itGodot(
+    'profile_project ranks the fixture hot loop with its source location',
+    async (ctx) => {
+      await launchProfilingSession(ctx);
+
+      const result = await handleProfileProject(runner, { seconds: 2, top: 10 });
+      expect(hasError(result)).toBe(false);
+
+      const capture = unwrap(result).structuredContent as unknown as CaptureShape;
+      expect(capture.frames).toBeGreaterThan(0);
+      const burn = capture.rows.find((row) => row.function === 'burn');
+      expect(
+        burn,
+        `no "burn" row in ${capture.rows.map((r) => r.function).join(', ')}`,
+      ).toBeDefined();
+      expect(burn!.file).toBe('res://hot_loop.gd');
+      expect(burn!.line).toBeGreaterThan(0);
+      expect(burn!.calls).toBeGreaterThan(0);
+      expect(burn!.selfMs).toBeGreaterThan(0);
+      // Own time dominates the frame, so the default ranking puts it first.
+      expect(capture.rows[0]!.function).toBe('burn');
+      expect(burn!.percentOfFrame).toBeGreaterThan(0);
+
+      // The editor's "Frame Time" category and its server rows.
+      expect(capture.frame.frameMs.avg).toBeGreaterThan(0);
+      expect(capture.frame.frameMs.max).toBeGreaterThanOrEqual(capture.frame.frameMs.avg);
+      expect(capture.frame.scriptMs.avg).toBeGreaterThan(0);
+      expect(capture.worstFrame.frameMs).toBeGreaterThan(0);
+      expect(
+        capture.servers.length,
+        `no server categories in ${JSON.stringify(capture.servers)}`,
+      ).toBeGreaterThan(0);
+      expect(capture.servers[0]!.functions.length).toBeGreaterThan(0);
+    },
+    90000,
+  );
+
+  itGodot(
+    'start_profiler records while other runtime tools drive the game, stop_profiler reports',
+    async (ctx) => {
+      await launchProfilingSession(ctx);
+
+      const started = await handleStartProfiler(runner, { seconds: 10 });
+      expect(hasError(started)).toBe(false);
+      expect(unwrap(started).structuredContent).toMatchObject({ active: true });
+
+      // A capture must survive normal bridge traffic in the middle of it.
+      await runner.sendCommand('get_ui_elements', {});
+
+      const stopped = await handleStopProfiler(runner, { top: 5, sort: 'calls' });
+      expect(hasError(stopped)).toBe(false);
+      const capture = unwrap(stopped).structuredContent as unknown as CaptureShape;
+      expect(capture.frames).toBeGreaterThan(0);
+      expect(capture.rows.map((row) => row.function)).toContain('burn');
+    },
+    90000,
+  );
+});

--- a/tests/unit/godot-variant.test.ts
+++ b/tests/unit/godot-variant.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The Variant codec is a boundary against bytes we don't control, so the
+ * interesting cases are the malformed ones: a length field that overruns the
+ * packet, a type outside the supported subset, trailing bytes after a value.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { decodeVariant, encodeVariant, type Variant } from '../../src/utils/godot-variant.js';
+
+function roundTrip(value: Variant): Variant {
+  return decodeVariant(encodeVariant(value));
+}
+
+describe('encodeVariant / decodeVariant round-trip', () => {
+  it.each([
+    ['null', null],
+    ['bool true', true],
+    ['bool false', false],
+    ['int', 42],
+    ['negative int', -7],
+    ['float', 0.015625],
+    ['string', 'servers:profile_frame'],
+    ['string needing padding', 'abc'],
+    ['empty string', ''],
+    ['non-ascii string', 'res://scène.gd::12::_procès'],
+    ['array', ['profiler:servers', 1, [true, [512, false]]]],
+  ] as Array<[string, Variant]>)('preserves %s', (_label, value) => {
+    expect(roundTrip(value)).toEqual(value);
+  });
+
+  it('rejects values Godot never accepts from a debugger host', () => {
+    expect(() => encodeVariant({ nope: 1 } as unknown as Variant)).toThrow(/Unsupported outgoing/);
+  });
+});
+
+describe('decodeVariant rejects malformed packets', () => {
+  it('rejects a truncated value', () => {
+    const raw = encodeVariant(1234);
+    expect(() => decodeVariant(raw.subarray(0, raw.length - 2))).toThrow(/Truncated/);
+  });
+
+  it('rejects a truncated string body', () => {
+    const raw = encodeVariant('godot');
+    expect(() => decodeVariant(raw.subarray(0, 10))).toThrow(/Truncated/);
+  });
+
+  it('rejects trailing bytes after a complete value', () => {
+    const raw = Buffer.concat([encodeVariant(1), Buffer.alloc(4)]);
+    expect(() => decodeVariant(raw)).toThrow(/Trailing Variant bytes/);
+  });
+
+  it('rejects an array length the packet cannot hold', () => {
+    const raw = Buffer.alloc(8);
+    raw.writeUInt32LE(28, 0);
+    raw.writeUInt32LE(1_000_000, 4);
+    expect(() => decodeVariant(raw)).toThrow(/Invalid array length/);
+  });
+
+  it('rejects a packed array length the packet cannot hold', () => {
+    const raw = Buffer.alloc(8);
+    raw.writeUInt32LE(30, 0);
+    raw.writeUInt32LE(1_000_000, 4);
+    expect(() => decodeVariant(raw)).toThrow(/Invalid packed array length/);
+  });
+
+  it('rejects an unsupported type (objects and vectors are never decoded)', () => {
+    const raw = Buffer.alloc(8);
+    raw.writeUInt32LE(24, 0);
+    expect(() => decodeVariant(raw)).toThrow(/Unsupported debugger Variant/);
+  });
+
+  it('decodes a packed float array as plain numbers', () => {
+    const raw = Buffer.alloc(8 + 8);
+    raw.writeUInt32LE(33, 0);
+    raw.writeUInt32LE(1, 4);
+    raw.writeDoubleLE(1.5, 8);
+    expect(decodeVariant(raw)).toEqual([1.5]);
+  });
+});

--- a/tests/unit/godot-variant.test.ts
+++ b/tests/unit/godot-variant.test.ts
@@ -77,3 +77,74 @@ describe('decodeVariant rejects malformed packets', () => {
     expect(decodeVariant(raw)).toEqual([1.5]);
   });
 });
+
+/**
+ * The encoder only ever emits the 64-bit form, so a round-trip test can never
+ * reach the 32-bit branch — but the wire format allows it and a real engine may
+ * send it. These build the narrow encodings by hand.
+ */
+describe('decodeVariant handles the encodings our encoder never emits', () => {
+  const TYPE_INT = 2;
+  const TYPE_FLOAT = 3;
+
+  function narrow(kind: number, write: (buf: Buffer) => void, width: number): Buffer {
+    const buf = Buffer.alloc(4 + width);
+    buf.writeUInt32LE(kind, 0);
+    write(buf);
+    return buf;
+  }
+
+  it('decodes a 32-bit int', () => {
+    const raw = narrow(TYPE_INT, (b) => b.writeInt32LE(-123456, 4), 4);
+    expect(decodeVariant(raw)).toBe(-123456);
+  });
+
+  it('decodes a 32-bit float', () => {
+    const raw = narrow(TYPE_FLOAT, (b) => b.writeFloatLE(0.5, 4), 4);
+    expect(decodeVariant(raw)).toBe(0.5);
+  });
+
+  it('decodes a StringName the same way as a String', () => {
+    const TYPE_STRING_NAME = 21;
+    const text = Buffer.from('physics_2d', 'utf8');
+    const raw = Buffer.alloc(8 + text.length + ((4 - (text.length % 4)) % 4));
+    raw.writeUInt32LE(TYPE_STRING_NAME, 0);
+    raw.writeUInt32LE(text.length, 4);
+    text.copy(raw, 8);
+    expect(decodeVariant(raw)).toBe('physics_2d');
+  });
+
+  it.each([
+    ['byte', 29, 1, (b: Buffer, at: number) => b.writeUInt8(7, at), 7],
+    ['int32', 30, 4, (b: Buffer, at: number) => b.writeInt32LE(-9, at), -9],
+    ['int64', 31, 8, (b: Buffer, at: number) => b.writeBigInt64LE(-9n, at), -9],
+    ['float32', 32, 4, (b: Buffer, at: number) => b.writeFloatLE(0.25, at), 0.25],
+    ['float64', 33, 8, (b: Buffer, at: number) => b.writeDoubleLE(0.1, at), 0.1],
+  ] as Array<[string, number, number, (b: Buffer, at: number) => void, number]>)(
+    'decodes a packed %s array',
+    (_label, kind, width, write, expected) => {
+      // The byte array is the only one that pads to a 4-byte boundary.
+      const pad = kind === 29 ? (4 - (1 % 4)) % 4 : 0;
+      const raw = Buffer.alloc(8 + width + pad);
+      raw.writeUInt32LE(kind, 0);
+      raw.writeUInt32LE(1, 4);
+      write(raw, 8);
+      expect(decodeVariant(raw)).toEqual([expected]);
+    },
+  );
+
+  it('rejects an array nested past the depth limit', () => {
+    // 65 opening ARRAY headers, each declaring one element.
+    const TYPE_ARRAY = 28;
+    const parts: Buffer[] = [];
+    for (let i = 0; i < 65; i++) {
+      const head = Buffer.alloc(8);
+      head.writeUInt32LE(TYPE_ARRAY, 0);
+      head.writeUInt32LE(1, 4);
+      parts.push(head);
+    }
+    const nil = Buffer.alloc(4);
+    parts.push(nil);
+    expect(() => decodeVariant(Buffer.concat(parts))).toThrow(/nesting limit/);
+  });
+});

--- a/tests/unit/handlers/profiler-handlers.test.ts
+++ b/tests/unit/handlers/profiler-handlers.test.ts
@@ -34,6 +34,7 @@ const captureResult = {
   firstFrame: 10,
   lastFrame: 309,
   frameGaps: 0,
+  undecodablePackets: 0,
   captureLimit: 512,
   limitReached: false,
   sort: 'selfMs',
@@ -44,7 +45,7 @@ const captureResult = {
 };
 
 function createProfilerFake(
-  options: { profiler?: boolean; exited?: boolean; throws?: Error } = {},
+  options: { profiler?: boolean; exited?: boolean; throws?: Error; session?: boolean } = {},
 ): ProfilerFake {
   const calls: ProfilerCall[] = [];
   const record = (method: ProfilerCall['method'], args: unknown[], result: unknown): unknown => {
@@ -71,6 +72,8 @@ function createProfilerFake(
   const runner = {
     activeProfiler: options.profiler === false ? null : (profiler as unknown as DebuggerProfiler),
     activeProcess: { hasExited: options.exited === true } as GodotProcess,
+    activeSessionMode: options.session === false ? null : 'spawned',
+    activeProjectPath: options.session === false ? null : 'D:/proj',
   };
   return { asRunner: runner as unknown as GodotRunner, calls };
 }
@@ -89,6 +92,15 @@ describe('profiler handlers — session requirements', () => {
     ['profile_project', handleProfileProject],
     ['start_profiler', handleStartProfiler],
     ['stop_profiler', handleStopProfiler],
+  ])('%s distinguishes no session at all from no profiling', async (_name, handler) => {
+    const fake = createProfilerFake({ profiler: false, session: false });
+    expectErrorMatching(await handler(fake.asRunner, {}), /No active runtime session/);
+  });
+
+  it.each([
+    ['profile_project', handleProfileProject],
+    ['start_profiler', handleStartProfiler],
+    ['stop_profiler', handleStopProfiler],
   ])('%s rejects a Godot process that already exited', async (_name, handler) => {
     const fake = createProfilerFake({ exited: true });
     expectErrorMatching(await handler(fake.asRunner, {}), /has exited/);
@@ -101,7 +113,7 @@ describe('handleProfileProject', () => {
     const result = await handleProfileProject(fake.asRunner, {});
 
     expect(hasError(result)).toBe(false);
-    expect(fake.calls[0]).toEqual({ method: 'captureWindow', args: [5, 20, 'selfMs'] });
+    expect(fake.calls[0]).toEqual({ method: 'captureWindow', args: [5, 20, 'selfMs', 512] });
     expect(unwrap(result).structuredContent).toMatchObject({ frames: 300, sort: 'selfMs' });
   });
 
@@ -109,7 +121,7 @@ describe('handleProfileProject', () => {
     const fake = createProfilerFake();
     await handleProfileProject(fake.asRunner, { seconds: 12, top: 5, sort: 'totalMs' });
 
-    expect(fake.calls[0]).toEqual({ method: 'captureWindow', args: [12, 5, 'totalMs'] });
+    expect(fake.calls[0]).toEqual({ method: 'captureWindow', args: [12, 5, 'totalMs', 512] });
   });
 
   it('rejects a sort key outside the enum', async () => {

--- a/tests/unit/handlers/profiler-handlers.test.ts
+++ b/tests/unit/handlers/profiler-handlers.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the profiler-tools handlers.
+ *
+ * The handlers own argument defaults, the sort enum, and the mapping from a
+ * `ProfilerError` code to a user-facing solution list. The receiver itself is
+ * covered in `unit/profiler.test.ts`, so here it is a stub that records what
+ * the handler asked it for.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  handleProfileProject,
+  handleStartProfiler,
+  handleStopProfiler,
+} from '../../../src/tools/profiler-tools.js';
+import { ProfilerError, type DebuggerProfiler } from '../../../src/utils/profiler.js';
+import type { GodotProcess, GodotRunner } from '../../../src/utils/godot-runner.js';
+import { expectErrorMatching, hasError, unwrap } from '../../helpers/assertions.js';
+
+interface ProfilerCall {
+  method: 'start' | 'stop' | 'captureWindow';
+  args: unknown[];
+}
+
+interface ProfilerFake {
+  asRunner: GodotRunner;
+  calls: ProfilerCall[];
+}
+
+const captureResult = {
+  seconds: 5,
+  frames: 300,
+  framesReceived: 301,
+  firstFrame: 10,
+  lastFrame: 309,
+  frameGaps: 0,
+  captureLimit: 512,
+  limitReached: false,
+  sort: 'selfMs',
+  functionsReceived: 2,
+  unresolvedFunctions: 0,
+  rows: [{ function: '_burn', selfMs: 480 }],
+  worstFrame: null,
+};
+
+function createProfilerFake(
+  options: { profiler?: boolean; exited?: boolean; throws?: Error } = {},
+): ProfilerFake {
+  const calls: ProfilerCall[] = [];
+  const record = (method: ProfilerCall['method'], args: unknown[], result: unknown): unknown => {
+    calls.push({ method, args });
+    if (options.throws) throw options.throws;
+    return result;
+  };
+  const profiler = {
+    async start(...args: unknown[]) {
+      return record('start', args, {
+        active: true,
+        maxSeconds: args[0],
+        firstFrame: 10,
+        captureLimit: args[1],
+      });
+    },
+    async stop(...args: unknown[]) {
+      return record('stop', args, { ...captureResult, sort: args[1] });
+    },
+    async captureWindow(...args: unknown[]) {
+      return record('captureWindow', args, { ...captureResult, sort: args[2] });
+    },
+  };
+  const runner = {
+    activeProfiler: options.profiler === false ? null : (profiler as unknown as DebuggerProfiler),
+    activeProcess: { hasExited: options.exited === true } as GodotProcess,
+  };
+  return { asRunner: runner as unknown as GodotRunner, calls };
+}
+
+describe('profiler handlers — session requirements', () => {
+  it.each([
+    ['profile_project', handleProfileProject],
+    ['start_profiler', handleStartProfiler],
+    ['stop_profiler', handleStopProfiler],
+  ])('%s rejects a session launched without profiling', async (_name, handler) => {
+    const fake = createProfilerFake({ profiler: false });
+    expectErrorMatching(await handler(fake.asRunner, {}), /Profiling is not enabled/);
+  });
+
+  it.each([
+    ['profile_project', handleProfileProject],
+    ['start_profiler', handleStartProfiler],
+    ['stop_profiler', handleStopProfiler],
+  ])('%s rejects a Godot process that already exited', async (_name, handler) => {
+    const fake = createProfilerFake({ exited: true });
+    expectErrorMatching(await handler(fake.asRunner, {}), /has exited/);
+  });
+});
+
+describe('handleProfileProject', () => {
+  it('captures a five-second window ranked by own time by default', async () => {
+    const fake = createProfilerFake();
+    const result = await handleProfileProject(fake.asRunner, {});
+
+    expect(hasError(result)).toBe(false);
+    expect(fake.calls[0]).toEqual({ method: 'captureWindow', args: [5, 20, 'selfMs'] });
+    expect(unwrap(result).structuredContent).toMatchObject({ frames: 300, sort: 'selfMs' });
+  });
+
+  it('forwards seconds, top and sort', async () => {
+    const fake = createProfilerFake();
+    await handleProfileProject(fake.asRunner, { seconds: 12, top: 5, sort: 'totalMs' });
+
+    expect(fake.calls[0]).toEqual({ method: 'captureWindow', args: [12, 5, 'totalMs'] });
+  });
+
+  it('rejects a sort key outside the enum', async () => {
+    const fake = createProfilerFake();
+    expectErrorMatching(
+      await handleProfileProject(fake.asRunner, { sort: 'wallMs' }),
+      /Invalid sort/,
+    );
+  });
+
+  it('rejects a non-numeric seconds before touching the profiler', async () => {
+    const fake = createProfilerFake();
+    expect(hasError(await handleProfileProject(fake.asRunner, { seconds: 'five' }))).toBe(true);
+    expect(fake.calls).toHaveLength(0);
+  });
+});
+
+describe('handleStartProfiler', () => {
+  it('defaults to a 30 second window at the full engine row limit', async () => {
+    const fake = createProfilerFake();
+    const result = await handleStartProfiler(fake.asRunner, {});
+
+    expect(fake.calls[0]).toEqual({ method: 'start', args: [30, 512] });
+    expect(unwrap(result).structuredContent).toMatchObject({ active: true, captureLimit: 512 });
+  });
+
+  it('accepts captureLimit in snake_case as well as camelCase', async () => {
+    const fake = createProfilerFake();
+    await handleStartProfiler(fake.asRunner, { seconds: 10, capture_limit: 64 });
+
+    expect(fake.calls[0]).toEqual({ method: 'start', args: [10, 64] });
+  });
+
+  it('explains how to clear an already-running capture', async () => {
+    const fake = createProfilerFake({
+      throws: new ProfilerError('profile_busy', 'A capture is already active'),
+    });
+    const result = await handleStartProfiler(fake.asRunner, {});
+
+    expectErrorMatching(result, /already active/);
+    expect(unwrap(result).content[1]?.text).toMatch(/stop_profiler/);
+  });
+});
+
+describe('handleStopProfiler', () => {
+  it('returns the top 20 by own time by default', async () => {
+    const fake = createProfilerFake();
+    const result = await handleStopProfiler(fake.asRunner, {});
+
+    expect(fake.calls[0]).toEqual({ method: 'stop', args: [20, 'selfMs'] });
+    expect(unwrap(result).structuredContent).toMatchObject({ sort: 'selfMs' });
+  });
+
+  it('points at start_profiler when no capture was started', async () => {
+    const fake = createProfilerFake({
+      throws: new ProfilerError('profile_not_started', 'Start a capture first'),
+    });
+    const result = await handleStopProfiler(fake.asRunner, {});
+
+    expectErrorMatching(result, /Start a capture first/);
+    expect(unwrap(result).content[1]?.text).toMatch(/start_profiler/);
+  });
+});

--- a/tests/unit/mcp-dispatch.test.ts
+++ b/tests/unit/mcp-dispatch.test.ts
@@ -64,6 +64,7 @@ describe('serverInstructions category coverage', () => {
     ['Scene editing', 'create_scene'],
     ['Node editing', 'delete_nodes'],
     ['Runtime', 'take_screenshot'],
+    ['Profiling', 'profile_project'],
     ['Project config', 'list_autoloads'],
     ['Validation', 'validate'],
   ];

--- a/tests/unit/output-schemas.test.ts
+++ b/tests/unit/output-schemas.test.ts
@@ -50,10 +50,13 @@ describe('outputSchema — expected coverage', () => {
     'get_node_signals',
     'get_scene_dependencies',
     'get_ui_elements',
+    'profile_project',
     'run_script',
     'search_project',
+    'start_profiler',
     'set_node_properties',
     'simulate_input',
+    'stop_profiler',
     'stop_project',
     'take_screenshot',
   ];

--- a/tests/unit/profiler.test.ts
+++ b/tests/unit/profiler.test.ts
@@ -4,9 +4,10 @@
  * which commands we send, which frames we fold into the totals, and what a
  * dropped or silent debugger turns into — none of which needs a real engine.
  *
- * The frame layout mirrors what Godot 4.6/4.7 actually sends: six timing
- * fields, a server count with that many `name, entryCount, ...entries`
- * blocks, then the flattened five-wide function rows behind their length.
+ * The frame layout mirrors what Godot 4.6/4.7 actually sends: a frame number,
+ * five timing fields, a server count with that many `name, entryCount,
+ * ...entries` blocks, then the flattened five-wide function rows behind their
+ * length.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -358,5 +359,141 @@ describe('DebuggerProfiler error contract', () => {
     const stopped = p.stop(10, 'selfMs');
     fake.close();
     await expect(stopped).rejects.toMatchObject({ code: 'profile_disconnected' });
+  });
+});
+
+describe('DebuggerProfiler capture quality signals', () => {
+  it('reports truncation from the rows the engine sent, not the rows we kept', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 16);
+    // 16 raw rows is the cap the engine was given, but half report no calls and
+    // get filtered — the truncation is real even though `rows` comes back short.
+    const rows: Row[] = [];
+    for (let i = 0; i < 16; i++) rows.push([i, i % 2 === 0 ? 0 : 3, 0.001, 0.002]);
+    await feedStart(fake, running, [
+      frame(1, 0.016, [[0, 1, 0.001, 0.002]]),
+      frame(2, 0.016, rows),
+    ]);
+
+    fake.send(['servers:profile_total', THREAD, frame(3, 0.016, [])]);
+    const result = await p.stop(10, 'selfMs');
+    expect(result.limitReached).toBe(true);
+  });
+
+  it('does not report truncation from the discarded boundary frame', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 16);
+    // The boundary frame is at the cap, but its numbers are thrown away, so the
+    // truncation it reports describes data no result ever contains.
+    const atCap: Row[] = [];
+    for (let i = 0; i < 16; i++) atCap.push([i, 5, 0.001, 0.002]);
+    await feedStart(fake, running, [
+      frame(1, 0.016, atCap),
+      frame(2, 0.016, [[0, 5, 0.001, 0.002]]),
+    ]);
+
+    fake.send(['servers:profile_total', THREAD, frame(3, 0.016, [])]);
+    const result = await p.stop(10, 'selfMs');
+    expect(result.limitReached).toBe(false);
+  });
+
+  it('does not report truncation from the totals packet', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 16);
+    await feedStart(fake, running, [
+      frame(1, 0.016, [[0, 1, 0.001, 0.002]]),
+      frame(2, 0.016, [[0, 5, 0.001, 0.002]]),
+    ]);
+
+    // The engine's totals list every function it saw all session. That row
+    // count hitting the limit says nothing about any one frame being cut.
+    const allSession: Row[] = [];
+    for (let i = 0; i < 16; i++) allSession.push([i, 5, 0.001, 0.002]);
+    fake.send(['servers:profile_total', THREAD, frame(3, 0.016, allSession)]);
+    const result = await p.stop(10, 'selfMs');
+    expect(result.limitReached).toBe(false);
+  });
+
+  it('refuses to summarize a capture that folded no frames', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 1, 'profiler enable');
+    // Only the boundary frame arrives, so nothing survives the discard. An
+    // all-zero payload here would read as "nothing in this game is slow".
+    fake.send(['servers:profile_frame', THREAD, frame(1, 0.016, [[0, 1, 0.001, 0.002]])]);
+    fake.send(['servers:profile_total', THREAD, frame(2, 0.016, [])]);
+    await running;
+
+    await expect(p.stop(10, 'selfMs')).rejects.toMatchObject({ code: 'profile_no_frames' });
+  });
+
+  it('rejects a frame whose counts are not whole numbers', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 1, 'profiler enable');
+    // A layout shift lands a timing value where the server count belongs.
+    const malformed = frame(1, 0.016, [[0, 1, 0.001, 0.002]]);
+    malformed[6] = 0.016;
+    fake.send(['servers:profile_frame', THREAD, malformed]);
+
+    await expect(running).rejects.toMatchObject({ code: 'profile_bad_frame' });
+  });
+});
+
+describe('DebuggerProfiler readability after the engine goes away', () => {
+  it('keeps a finished capture readable and re-rankable', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await feedStart(fake, running, [
+      frame(1, 0.016, [[0, 1, 0.001, 0.002]]),
+      frame(2, 0.016, [
+        [0, 3, 0.009, 0.012],
+        [1, 9, 0.001, 0.004],
+      ]),
+    ]);
+    fake.send(['servers:profile_total', THREAD, frame(3, 0.016, [])]);
+    await p.stop(10, 'selfMs');
+
+    expect(p.hasResult).toBe(true);
+    // The peer dropping is exactly the post-crash case worth reading back.
+    fake.close();
+    await waitUntil(() => !p.connected, 'peer disconnect');
+    const reread = await p.stop(1, 'calls');
+    expect(p.hasResult).toBe(true);
+    expect(reread.rows[0]?.function).toBe('_other');
+  });
+
+  it('ignores a second totals packet instead of corrupting the result', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await feedStart(fake, running, [
+      frame(1, 0.016, [[0, 1, 0.001, 0.002]]),
+      frame(2, 0.016, [[0, 4, 0.008, 0.01]]),
+    ]);
+    fake.send(['servers:profile_total', THREAD, frame(3, 0.016, [])]);
+    const first = await p.stop(10, 'selfMs');
+
+    fake.send(['servers:profile_total', THREAD, frame(4, 0.016, [[0, 999, 9, 9]])]);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const second = await p.stop(10, 'selfMs');
+    expect(second.rows[0]?.calls).toBe(first.rows[0]?.calls);
+  });
+
+  it('answers a mid-capture debug_enter without disturbing the capture', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 1, 'profiler enable');
+    fake.send(['servers:function_signature', THREAD, ['res://hot.gd::8::_burn', 0]]);
+    fake.send(['servers:profile_frame', THREAD, frame(1, 0.016, [[0, 1, 0.001, 0.002]])]);
+    // A script error mid-capture must resume the game, not strand the capture.
+    fake.send(['debug_enter', THREAD, [true, 'Breakpoint']]);
+    fake.send(['servers:profile_frame', THREAD, frame(2, 0.016, [[0, 6, 0.006, 0.009]])]);
+    await running;
+
+    fake.send(['servers:profile_total', THREAD, frame(3, 0.016, [])]);
+    const result = await p.stop(10, 'selfMs');
+    await waitUntil(() => fake.commandsNamed('continue').length === 1, 'continue reply');
+    expect(result.frames).toBe(1);
+    expect(result.rows[0]?.calls).toBe(6);
   });
 });

--- a/tests/unit/profiler.test.ts
+++ b/tests/unit/profiler.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Profiler receiver tests, driven by a fake Godot on the other end of the
+ * debugger socket. Everything worth verifying here is protocol behavior —
+ * which commands we send, which frames we fold into the totals, and what a
+ * dropped or silent debugger turns into — none of which needs a real engine.
+ *
+ * The frame layout mirrors what Godot 4.6/4.7 actually sends: six timing
+ * fields, a server count with that many `name, entryCount, ...entries`
+ * blocks, then the flattened five-wide function rows behind their length.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as net from 'net';
+import { decodeVariant, encodeVariant, type Variant } from '../../src/utils/godot-variant.js';
+import { DebuggerProfiler, ProfilerError } from '../../src/utils/profiler.js';
+
+const THREAD = 1;
+
+type Row = [id: number, calls: number, selfSeconds: number, totalSeconds: number];
+
+/** One `servers:profile_frame` payload, optionally preceded by server blocks. */
+function frame(
+  frameNumber: number,
+  frameSeconds: number,
+  rows: Row[],
+  servers: Array<[string, Array<string | number>]> = [],
+): Variant[] {
+  const serverBlocks: Variant[] = [];
+  for (const [name, entries] of servers) {
+    serverBlocks.push(name, entries.length, ...entries);
+  }
+  const flat: Variant[] = [];
+  for (const [id, calls, selfSeconds, totalSeconds] of rows) {
+    flat.push(id, calls, selfSeconds, totalSeconds, 0);
+  }
+  return [
+    frameNumber,
+    frameSeconds,
+    0.001,
+    0.001,
+    0.016,
+    0.001,
+    servers.length,
+    ...serverBlocks,
+    flat.length,
+    ...flat,
+  ];
+}
+
+class FakeGodot {
+  readonly commands: Variant[] = [];
+  private buffer = Buffer.alloc(0);
+
+  private constructor(private readonly socket: net.Socket) {
+    socket.on('data', (chunk: Buffer) => {
+      this.buffer = Buffer.concat([this.buffer, chunk]);
+      while (this.buffer.length >= 4) {
+        const size = this.buffer.readUInt32LE(0);
+        if (this.buffer.length < 4 + size) return;
+        this.commands.push(decodeVariant(this.buffer.subarray(4, 4 + size)));
+        this.buffer = this.buffer.subarray(4 + size);
+      }
+    });
+  }
+
+  static connect(port: number): Promise<FakeGodot> {
+    return new Promise((resolve, reject) => {
+      const socket = net.createConnection({ port, host: '127.0.0.1' }, () => {
+        resolve(new FakeGodot(socket));
+      });
+      socket.once('error', reject);
+    });
+  }
+
+  send(message: Variant): void {
+    const raw = encodeVariant(message);
+    const header = Buffer.alloc(4);
+    header.writeUInt32LE(raw.length, 0);
+    this.socket.write(Buffer.concat([header, raw]));
+  }
+
+  /** Commands the profiler sent us, by name. */
+  commandsNamed(name: string): Variant[][] {
+    return this.commands.filter(
+      (c): c is Variant[] => Array.isArray(c) && c[0] === name,
+    ) as Variant[][];
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+}
+
+async function waitUntil(predicate: () => boolean, label: string, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`Timed out waiting for ${label}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+let profiler: DebuggerProfiler | null = null;
+let peer: FakeGodot | null = null;
+
+afterEach(() => {
+  peer?.close();
+  profiler?.close();
+  peer = null;
+  profiler = null;
+});
+
+/** A profiler with a connected fake engine that has already reported its pid. */
+async function connectedProfiler(): Promise<{ profiler: DebuggerProfiler; peer: FakeGodot }> {
+  profiler = await DebuggerProfiler.create();
+  peer = await FakeGodot.connect(profiler.port);
+  peer.send(['set_pid', THREAD, [4242]]);
+  await waitUntil(() => profiler!.connected, 'set_pid');
+  return { profiler, peer };
+}
+
+/** Feed a boundary frame plus `frames`, then resolve the pending start(). */
+async function feedStart(
+  fake: FakeGodot,
+  running: Promise<unknown>,
+  frames: Variant[][],
+): Promise<void> {
+  await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 1, 'profiler enable');
+  fake.send(['servers:function_signature', THREAD, ['res://hot.gd::8::_burn', 0]]);
+  fake.send(['servers:function_signature', THREAD, ['res://hot.gd::14::_other', 1]]);
+  for (const payload of frames) fake.send(['servers:profile_frame', THREAD, payload]);
+  await running;
+}
+
+describe('DebuggerProfiler capture', () => {
+  it('enables the engine profiler with the requested row limit', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 256);
+    await feedStart(fake, running, [frame(10, 0.01, [[0, 1, 0.001, 0.002]]), frame(11, 0.02, [])]);
+
+    expect(fake.commandsNamed('profiler:servers')[0]).toEqual([
+      'profiler:servers',
+      THREAD,
+      [true, [256, false]],
+    ]);
+    expect(await running).toMatchObject({ active: true, maxSeconds: 5, captureLimit: 256 });
+  });
+
+  it('sums received frames, skips the boundary frame, and ranks by own time', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await feedStart(fake, running, [
+      // Boundary frame: enabling inside a VM call makes this sample fiction.
+      frame(10, 0.5, [[0, 99, 0.5, 0.5]]),
+      frame(
+        11,
+        0.02,
+        [
+          [0, 2, 0.004, 0.006],
+          [1, 1, 0.001, 0.001],
+        ],
+        [['audio_thread', ['audio_driver_process', 0.002, 'audio_server_process', 0.001]]],
+      ),
+      // Frame 12 never arrives — one transport gap.
+      frame(13, 0.01, [[0, 1, 0.002, 0.003]]),
+    ]);
+
+    const stopped = p.stop(10, 'selfMs');
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 2, 'profiler disable');
+    expect(fake.commandsNamed('profiler:servers')[1]).toEqual([
+      'profiler:servers',
+      THREAD,
+      [false],
+    ]);
+    fake.send(['servers:profile_total', THREAD, frame(13, 0.01, [])]);
+    const result = await stopped;
+
+    expect(result).toMatchObject({
+      frames: 2,
+      framesReceived: 3,
+      firstFrame: 11,
+      lastFrame: 13,
+      frameGaps: 1,
+      limitReached: false,
+      functionsReceived: 2,
+      unresolvedFunctions: 0,
+      sort: 'selfMs',
+    });
+    const [burn, other] = result.rows;
+    expect(burn).toMatchObject({
+      function: '_burn',
+      file: 'res://hot.gd',
+      line: 8,
+      calls: 3,
+      sourceResolved: true,
+    });
+    expect(burn!.selfMs).toBeCloseTo(6, 6);
+    expect(burn!.totalMs).toBeCloseTo(9, 6);
+    expect(burn!.callsPerFrame).toBeCloseTo(1.5, 6);
+    expect(burn!.msPerCall).toBeCloseTo(3, 6);
+    expect(burn!.peak).toMatchObject({ frame: 11 });
+    expect(other!.function).toBe('_other');
+    // 4.5 ms of a 15 ms average frame — the editor's "Frame %" measure.
+    expect(burn!.percentOfFrame).toBeCloseTo(30, 6);
+    expect(result.worstFrame).toMatchObject({ frame: 11 });
+    expect(result.worstFrame!.frameMs).toBeCloseTo(20, 6);
+    expect(result.worstFrame!.physicsFrameMs).toBeCloseTo(16, 6);
+  });
+
+  it('averages the engine frame budget and the server timings over the capture', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await feedStart(fake, running, [
+      frame(10, 0.5, [[0, 99, 0.5, 0.5]]),
+      frame(
+        11,
+        0.02,
+        [[0, 2, 0.004, 0.006]],
+        [['audio_thread', ['audio_driver_process', 0.002, 'audio_server_process', 0.001]]],
+      ),
+      frame(13, 0.01, [[0, 1, 0.002, 0.003]]),
+    ]);
+    const stopped = p.stop(10, 'selfMs');
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 2, 'profiler disable');
+    fake.send(['servers:profile_total', THREAD, frame(13, 0.01, [])]);
+    const result = await stopped;
+
+    // Frames 11 (20 ms) and 13 (10 ms); the boundary frame's 500 ms is excluded.
+    expect(result.frame.frameMs.avg).toBeCloseTo(15, 6);
+    expect(result.frame.frameMs.max).toBeCloseTo(20, 6);
+    expect(result.frame.processMs.avg).toBeCloseTo(1, 6);
+    expect(result.frame.physicsFrameMs.avg).toBeCloseTo(16, 6);
+    expect(result.frame.scriptMs.avg).toBeCloseTo(1, 6);
+
+    // The server block arrived in one of the two frames, so its cost halves.
+    expect(result.servers).toHaveLength(1);
+    const audio = result.servers[0]!;
+    expect(audio.name).toBe('audio_thread');
+    expect(audio.msPerFrame).toBeCloseTo(1.5, 6);
+    expect(audio.functions.map((f) => f.name)).toEqual([
+      'audio_driver_process',
+      'audio_server_process',
+    ]);
+    expect(audio.functions[0]!.msPerFrame).toBeCloseTo(1, 6);
+  });
+
+  it('re-reads a finished capture under a different sort', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await feedStart(fake, running, [
+      frame(1, 0.01, []),
+      frame(
+        2,
+        0.01,
+        [
+          [0, 1, 0.005, 0.005],
+          [1, 50, 0.001, 0.001],
+        ],
+        [],
+      ),
+    ]);
+    const stopped = p.stop(10, 'selfMs');
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 2, 'profiler disable');
+    fake.send(['servers:profile_total', THREAD, frame(2, 0.01, [])]);
+    expect((await stopped).rows[0]!.function).toBe('_burn');
+
+    const byCalls = await p.stop(1, 'calls');
+    expect(byCalls.rows).toHaveLength(1);
+    expect(byCalls.rows[0]!.function).toBe('_other');
+  });
+
+  it('reports unresolved signature ids instead of dropping their cost', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await feedStart(fake, running, [frame(1, 0.01, []), frame(2, 0.01, [[77, 1, 0.001, 0.001]])]);
+    const stopped = p.stop(10, 'selfMs');
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 2, 'profiler disable');
+    fake.send(['servers:profile_total', THREAD, frame(2, 0.01, [])]);
+    const result = await stopped;
+
+    expect(result.unresolvedFunctions).toBe(1);
+    expect(result.rows[0]).toMatchObject({ signature: '<unresolved:77>', sourceResolved: false });
+  });
+
+  it('flags a capture that hit the engine row limit', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 16);
+    const rows: Row[] = Array.from({ length: 16 }, (_, i) => [i, 1, 0.001, 0.001]);
+    await feedStart(fake, running, [frame(1, 0.01, []), frame(2, 0.01, rows)]);
+    const stopped = p.stop(10, 'totalMs');
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 2, 'profiler disable');
+    fake.send(['servers:profile_total', THREAD, frame(2, 0.01, [])]);
+
+    expect((await stopped).limitReached).toBe(true);
+  });
+
+  it('stops itself at the time limit without a stop_profiler call', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(0.2, 512);
+    await feedStart(fake, running, [frame(1, 0.01, []), frame(2, 0.01, [[0, 1, 0.001, 0.001]])]);
+
+    await waitUntil(() => fake.commandsNamed('profiler:servers').length >= 2, 'automatic stop');
+    fake.send(['servers:profile_total', THREAD, frame(2, 0.01, [])]);
+    expect((await p.stop(10, 'selfMs')).frames).toBe(1);
+  });
+
+  it('resumes the game when Godot breaks on an error or breakpoint', async () => {
+    const { peer: fake } = await connectedProfiler();
+    fake.send(['debug_enter', THREAD, [false, 'Cannot call method on a null value.', true, 1]]);
+
+    await waitUntil(() => fake.commandsNamed('continue').length === 1, 'continue');
+    expect(fake.commandsNamed('continue')[0]).toEqual(['continue', THREAD, []]);
+  });
+});
+
+describe('DebuggerProfiler error contract', () => {
+  it('refuses a second capture while one is active', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await feedStart(fake, running, [frame(1, 0.01, []), frame(2, 0.01, [[0, 1, 0.001, 0.001]])]);
+
+    await expect(p.start(5, 512)).rejects.toMatchObject({ code: 'profile_busy' });
+  });
+
+  it('refuses to stop a capture that was never started', async () => {
+    const { profiler: p } = await connectedProfiler();
+    await expect(p.stop(10, 'selfMs')).rejects.toMatchObject({ code: 'profile_not_started' });
+  });
+
+  it.each([
+    ['seconds of 0', 0, 512, 10],
+    ['seconds beyond the 60s ceiling', 61, 512, 10],
+    ['a capture limit below the engine range', 5, 8, 10],
+    ['a capture limit above the engine range', 5, 1024, 10],
+  ])('rejects %s', async (_label, seconds, limit) => {
+    const { profiler: p } = await connectedProfiler();
+    await expect(p.start(seconds, limit)).rejects.toMatchObject({ code: 'bad_args' });
+  });
+
+  it.each([
+    ['top below 1', 0, 'selfMs'],
+    ['top above 100', 101, 'selfMs'],
+    ['an unknown sort key', 10, 'wallMs'],
+  ])('rejects %s', async (_label, top, sort) => {
+    const { profiler: p } = await connectedProfiler();
+    await expect(p.stop(top, sort as 'selfMs')).rejects.toBeInstanceOf(ProfilerError);
+  });
+
+  it('times out when Godot never sends a frame', async () => {
+    profiler = await DebuggerProfiler.create();
+    await expect(profiler.start(5, 512)).rejects.toMatchObject({ code: 'profile_timeout' });
+  }, 10000);
+
+  it('surfaces a dropped debugger connection as a disconnect', async () => {
+    const { profiler: p, peer: fake } = await connectedProfiler();
+    const running = p.start(5, 512);
+    await feedStart(fake, running, [frame(1, 0.01, []), frame(2, 0.01, [[0, 1, 0.001, 0.001]])]);
+
+    const stopped = p.stop(10, 'selfMs');
+    fake.close();
+    await expect(stopped).rejects.toMatchObject({ code: 'profile_disconnected' });
+  });
+});

--- a/tests/unit/tool-definitions.test.ts
+++ b/tests/unit/tool-definitions.test.ts
@@ -4,6 +4,7 @@ import { autoloadToolDefinitions } from '../../src/tools/autoload-tools.js';
 import { projectToolDefinitions } from '../../src/tools/project-tools.js';
 import { sceneToolDefinitions } from '../../src/tools/scene-tools.js';
 import { nodeToolDefinitions } from '../../src/tools/node-tools.js';
+import { profilerToolDefinitions } from '../../src/tools/profiler-tools.js';
 import { validateToolDefinitions } from '../../src/tools/validate-tools.js';
 import type { ToolDefinition } from '../../src/mcp.types.js';
 
@@ -13,6 +14,7 @@ const allDefinitions: ToolDefinition[] = [
   ...projectToolDefinitions,
   ...sceneToolDefinitions,
   ...nodeToolDefinitions,
+  ...profilerToolDefinitions,
   ...validateToolDefinitions,
 ];
 


### PR DESCRIPTION
## Problem

The runtime bridge can run the game, look at it and script against it, but not measure it: a scene that stutters comes back as "feels slow", with no way to name the function paying for it. Godot already computes exactly that for its own Profiler tab and ships it over the remote debugger, so a spawned session can read it with no addon and nothing written into the project.

## Changes

`run_project` gains `profiling: true`, which binds a loopback listener before the spawn and passes `--remote-debug tcp://127.0.0.1:<port>`. Three tools read that channel: `profile_project` captures a bounded window (default 5 s, max 60); `start_profiler` / `stop_profiler` bracket one that `simulate_input` or `run_script` can drive, and a finished capture can be re-read under a different sort.

A capture returns the three groups the editor's tree shows — `rows[]` (function, file, function-start line, calls, `selfMs`/`totalMs`, per-frame averages, `msPerCall`, `percentOfFrame`, peak frame), `frame` (`frameMs`/`processMs`/`physicsMs`/`scriptMs` as `{avg, max}`) and `servers[]` — plus `worstFrame`.

- A connected debugger pauses the game on script errors and on `breakpoint`, which would freeze the window mid-session, so every `debug_enter` is answered with `continue`
- The first received frame is discarded: enabling the profiler inside a running VM call gives that sample a zero start timestamp
- The channel exists only if it was on the command line at launch, so `attach_project` sessions say so rather than returning empty numbers
- `godot-variant.ts` decodes only the Variant subset the debugger speaks; the frame layout is checked against `servers_debugger.cpp` and `script_editor_debugger.cpp` in 4.7.1

`docs/tools.md` maps each field to its editor column and records what the numbers cannot say: elapsed rather than CPU time, inclusive rows overlapping, capped rows and frame gaps making totals lower bounds.

## Tests

Unit: a fake debugger peer over a real socket (aggregation, discarded boundary frame, frame gaps, automatic stop, `debug_enter` → `continue`, error codes), the Variant codec including malformed packets, and handler defaults plus the `ProfilerError` → solutions mapping. Integration: a live capture against a new hot-loop fixture, asserting the hot function ranks first with its source location and that the frame budget and server categories come through. Verified against Godot 4.6.3 and 4.7 on Windows.
