### PR TITLE
feat(scene): guard scene mutations against live runtime sessions

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -9,8 +9,8 @@ The full MCP tool reference for Godot MCP Runtime. This file always reflects `ma
 | `launch_editor`    | Open the Godot editor GUI for a project                                                                                                                                                                                                  |
 | `run_project`      | Run a project and inject the MCP bridge. Pass `background: true` to hide the window; `profiling: true` to enable the profiling tools; pass `bridgePort` (integer 1–65535) to pin the bridge port — auto-selects a free port when omitted |
 | `attach_project`   | Inject the MCP bridge for a project you'll launch yourself. Pass `bridgePort` (integer 1–65535) to pin a specific port — auto-selects a free port when omitted                                                                           |
-| `detach_project`   | Remove the injected bridge after manual-launch use, leaving the external process alone                                                                                                                                                   |
-| `stop_project`     | Stop the running project and remove the bridge (also detaches attached-mode state)                                                                                                                                                       |
+| `detach_project`   | Remove the injected bridge after manual-launch use, leaving the external process alone. Call it even if that process is already closed — it clears state that otherwise blocks scene-editing tools                                       |
+| `stop_project`     | Stop the running project and remove the bridge (also detaches attached-mode state). Call it even if you closed the Godot window yourself — it clears state that otherwise blocks scene-editing tools                                     |
 | `get_debug_output` | Read stdout/stderr from an MCP-spawned project (unavailable in attached mode)                                                                                                                                                            |
 | `list_projects`    | Find Godot projects in a directory                                                                                                                                                                                                       |
 | `get_project_info` | Get project metadata and Godot version                                                                                                                                                                                                   |
@@ -67,6 +67,8 @@ While the debugger is attached, a script error or a `breakpoint` would normally 
 
 All mutation operations save automatically. Use `save_scene` only for save-as (`newPath`) or to re-canonicalize a `.tscn` file.
 
+Every tool below errors while a Godot runtime session is active on the same project — a running process can write its own scene files at any point, so a headless write would race it. Call `stop_project` (or `detach_project`) to clear the block.
+
 | Tool                     | Description                                                                              |
 | ------------------------ | ---------------------------------------------------------------------------------------- |
 | `create_scene`           | Create a new scene file                                                                  |
@@ -87,6 +89,8 @@ Every path argument is confined to the project root. A path that resolves outsid
 ## Node Editing (headless)
 
 All mutation operations save automatically. Property and delete tools take always-array input — pass a single-element array for one-off operations, or many for batched work in one Godot process.
+
+`set_node_properties`, `attach_script`, `duplicate_node`, `delete_nodes`, `connect_signal`, and `disconnect_signal` error while a Godot runtime session is active on the same project — a running process can write its own scene files at any point, so a headless write would race it. Call `stop_project` (or `detach_project`) to clear the block. The three read-only tools (`get_scene_tree`, `get_node_properties`, `get_node_signals`) are unaffected.
 
 | Tool                  | Description                                                               |
 | --------------------- | ------------------------------------------------------------------------- |

--- a/src/tools/node-tools.ts
+++ b/src/tools/node-tools.ts
@@ -28,7 +28,7 @@ export const nodeToolDefinitions = [
   {
     name: 'delete_nodes',
     description:
-      'Remove one or more nodes (and their descendants) from a scene file. Always-array: pass a single-element nodePaths array for one-off deletes. Saves once at the end. Cannot delete the scene root — that entry returns an error and the rest still process. Returns: results array with one entry per nodePath in input order (success or error message).',
+      'Remove one or more nodes (and their descendants) from a scene file. Always-array: pass a single-element nodePaths array for one-off deletes. Saves once at the end. Cannot delete the scene root — that entry returns an error and the rest still process. Returns: results array with one entry per nodePath in input order (success or error message). Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
@@ -66,7 +66,7 @@ export const nodeToolDefinitions = [
   {
     name: 'set_node_properties',
     description:
-      "Set one or more node properties on a scene in one Godot process. Always-array: pass a single-element updates array for one-off edits. {x,y} / {x,y,z} / {r,g,b,a} auto-convert to Vector2 / Vector3 / Color. Values are checked against the property's declared type and error instead of silently storing that type's zero value. Object-typed properties (e.g. CollisionShape2D.shape) take a res:// path, a typed dict {type: ClassName, ...props} that constructs a Resource inline, or null to clear. Full value rules: the Property Values section of docs/tools.md. abortOnError stops on first failure (default false continues). Saves once at the end. Returns: results[] with one entry per update in input order (success or error).",
+      "Set one or more node properties on a scene in one Godot process. Always-array: pass a single-element updates array for one-off edits. {x,y} / {x,y,z} / {r,g,b,a} auto-convert to Vector2 / Vector3 / Color. Values are checked against the property's declared type and error instead of silently storing that type's zero value. Object-typed properties (e.g. CollisionShape2D.shape) take a res:// path, a typed dict {type: ClassName, ...props} that constructs a Resource inline, or null to clear. Full value rules: the Property Values section of docs/tools.md. abortOnError stops on first failure (default false continues). Saves once at the end. Returns: results[] with one entry per update in input order (success or error). Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.",
     annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
@@ -153,7 +153,7 @@ export const nodeToolDefinitions = [
   {
     name: 'attach_script',
     description:
-      'Attach an existing GDScript file to a node in a scene. Use after writing the script with the standard file tools and validating it via the validate tool. Replaces any previously attached script. Saves automatically. Returns: success with the resolved nodePath and scriptPath that were attached. Errors if scriptPath does not exist or nodePath is not found.',
+      'Attach an existing GDScript file to a node in a scene. Use after writing the script with the standard file tools and validating it via the validate tool. Replaces any previously attached script. Saves automatically. Returns: success with the resolved nodePath and scriptPath that were attached. Errors if scriptPath does not exist or nodePath is not found. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
@@ -204,7 +204,7 @@ export const nodeToolDefinitions = [
   {
     name: 'duplicate_node',
     description:
-      'Duplicate a node and its descendants in a Godot scene. Use to clone a configured subtree without re-creating it node-by-node via add_node. newName defaults to the original name + "2"; targetParentPath defaults to the original parent. Saves automatically. Returns: success with originalPath and the newPath where the duplicate now lives — use newPath for follow-up edits. Errors if nodePath does not exist or targetParentPath cannot accept children.',
+      'Duplicate a node and its descendants in a Godot scene, without rebuilding it node-by-node via add_node. newName defaults to the original name + "2"; targetParentPath defaults to the original parent. Saves automatically. Returns: success with originalPath and the newPath where the duplicate now lives. Errors if nodePath does not exist or targetParentPath cannot accept children. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -276,7 +276,7 @@ export const nodeToolDefinitions = [
   {
     name: 'connect_signal',
     description:
-      'Connect a signal on a source node to a method on a target node, persisting the connection in the .tscn. Use after get_node_signals to confirm the signal name on the source and the method name on the target. Connecting the same signal+method pair twice creates a duplicate connection — call get_node_signals first if uncertain. Saves automatically. Returns a plain-text confirmation naming the source, signal, target, and method. Errors if the signal does not exist on the source node or the method does not exist on the target node.',
+      'Connect a signal on a source node to a method on a target node, persisting it in the .tscn. Use get_node_signals first to confirm names — connecting the same pair twice creates a duplicate connection. Saves automatically. Returns a plain-text confirmation naming source, signal, target, and method. Errors if the signal or method does not exist. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -302,7 +302,7 @@ export const nodeToolDefinitions = [
   {
     name: 'disconnect_signal',
     description:
-      'Remove an existing signal connection between two nodes, persisting the change in the .tscn. Use get_node_signals first to confirm the connection exists; recovery requires reconnecting via connect_signal. Saves automatically. Returns a plain-text confirmation naming the disconnected signal and target. Errors if the connection does not exist.',
+      'Remove an existing signal connection between two nodes, persisting the change in the .tscn. Use get_node_signals first to confirm the connection exists; recovery requires reconnecting via connect_signal. Saves automatically. Returns a plain-text confirmation naming the disconnected signal and target. Errors if the connection does not exist. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
@@ -347,7 +347,7 @@ export async function handleDeleteNodes(
     'Failed to delete nodes',
     ['Check if the node paths are correct'],
     undefined,
-    { parseStdoutAsJson: true },
+    { parseStdoutAsJson: true, mutatesSceneFile: true },
   );
 }
 
@@ -378,7 +378,7 @@ export async function handleSetNodeProperties(
     'Failed to set node properties',
     ['Check node paths and property names'],
     undefined,
-    { parseStdoutAsJson: true },
+    { parseStdoutAsJson: true, mutatesSceneFile: true },
   );
 }
 
@@ -446,7 +446,7 @@ export async function handleAttachScript(
     'Failed to attach script',
     ['Ensure the script is valid for this node type'],
     undefined,
-    { parseStdoutAsJson: true },
+    { parseStdoutAsJson: true, mutatesSceneFile: true },
   );
 }
 
@@ -508,7 +508,7 @@ export async function handleDuplicateNode(
     'Failed to duplicate node',
     ['Check if the node path and target parent path are correct'],
     undefined,
-    { parseStdoutAsJson: true },
+    { parseStdoutAsJson: true, mutatesSceneFile: true },
   );
 }
 
@@ -593,6 +593,8 @@ export async function handleConnectSignal(
     parsed.value.projectPath,
     'Failed to connect signal',
     ['Ensure the signal exists on the source node and the method exists on the target node'],
+    undefined,
+    { mutatesSceneFile: true },
   );
 }
 
@@ -618,5 +620,7 @@ export async function handleDisconnectSignal(
     parsed.value.projectPath,
     'Failed to disconnect signal',
     ['Ensure the signal connection exists before trying to disconnect it'],
+    undefined,
+    { mutatesSceneFile: true },
   );
 }

--- a/src/tools/runtime-tools.ts
+++ b/src/tools/runtime-tools.ts
@@ -138,7 +138,7 @@ export const runtimeToolDefinitions = [
   {
     name: 'detach_project',
     description:
-      'Clear attached-mode runtime state and remove the injected McpBridge autoload. Does NOT stop the manually launched Godot process — that stays running. Use after attach_project when you are done driving the game from MCP. For spawned sessions (run_project), use stop_project instead. Returns: message confirming detach plus externalProcessPreserved (always true here — that is the point of detach vs stop_project). Errors if called outside an attached session.',
+      'Clear attached-mode runtime state and remove the injected McpBridge autoload. Does NOT stop the manually launched Godot process — that stays running. Use after attach_project when you are done driving the game from MCP. For spawned sessions (run_project), use stop_project instead. Returns: message confirming detach plus externalProcessPreserved (always true here — that is the point of detach vs stop_project). Errors if called outside an attached session. Call this even if the externally launched Godot process is already closed — it clears the session flag that blocks scene-editing tools and removes the bridge autoload the project would otherwise be left with.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
@@ -183,7 +183,7 @@ export const runtimeToolDefinitions = [
   {
     name: 'stop_project',
     description:
-      'Stop the spawned Godot project and clean up MCP bridge state. Always call when done with runtime testing, even after a crash, to free the process slot for run_project. Attached sessions detach without killing the external process. Returns: message, mode ("spawned"/"attached"), externalProcessPreserved (true only for attached), and condensed finalOutput/finalErrors (blank and startup-banner lines dropped, capped at 200 lines); get_debug_output has the full log. Errors if no session is active.',
+      'Stop the spawned Godot project and clean up bridge state. Call when done with runtime testing, even after a crash, and even if you closed the Godot window yourself: it frees the process slot, clears the flag blocking scene-editing tools, and removes the bridge autoload left in the project. Attached sessions detach without killing the external process. Returns: message, mode, externalProcessPreserved, and condensed finalOutput/finalErrors (capped at 200); get_debug_output has the full log. Errors if no session is active.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',

--- a/src/tools/scene-tools.ts
+++ b/src/tools/scene-tools.ts
@@ -23,7 +23,7 @@ export const sceneToolDefinitions = [
   {
     name: 'create_scene',
     description:
-      'Create a new Godot scene file with a single root node. Writes a fresh .tscn at scenePath. Use when starting a new scene from scratch; for adding nodes to an existing scene, use add_node. rootNodeType defaults to Node2D — pass "Node3D" for 3D scenes or "Control" for UI. Saves automatically. Overwrites silently if the file already exists. Returns: success and the scenePath that was written.',
+      'Create a new Godot scene file with a single root node. Writes a fresh .tscn at scenePath. Use when starting a new scene from scratch; for adding nodes to an existing scene, use add_node. rootNodeType defaults to Node2D — pass "Node3D" for 3D scenes or "Control" for UI. Saves automatically. Overwrites silently if the file already exists. Returns: success and the scenePath that was written. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
@@ -48,7 +48,7 @@ export const sceneToolDefinitions = [
   {
     name: 'add_node',
     description:
-      "Add a node to a Godot scene. Saves automatically. Common spatial properties (position, rotation, scale, visible, modulate) are top-level params; anything else goes under properties. {x,y} / {x,y,z} / {r,g,b,a} auto-convert to Vector2 / Vector3 / Color. Values are checked against the property's declared type and error instead of silently storing that type's zero value. Object-typed properties take a res:// path, a typed dict {type: ClassName, ...props} that constructs a Resource inline, or null. Full value rules: the Property Values section of docs/tools.md. parentNodePath defaults to the scene root. Returns a plain-text confirmation naming the new node and type. Errors, and adds nothing, if nodeType is not a registered Godot class, parentNodePath does not exist, or a property name or value is invalid.",
+      "Add a node to a Godot scene. Saves automatically. Common spatial properties (position, rotation, scale, visible, modulate) are top-level params; anything else goes under properties. {x,y} / {x,y,z} / {r,g,b,a} auto-convert to Vector2 / Vector3 / Color. Values are checked against the property's declared type and error instead of silently storing that type's zero value. Object-typed properties take a res:// path, a typed dict {type: ClassName, ...props} that constructs a Resource inline, or null. Full value rules: the Property Values section of docs/tools.md. parentNodePath defaults to the scene root. Returns a plain-text confirmation naming the new node and type. Errors, and adds nothing, if nodeType is not a registered Godot class, parentNodePath does not exist, or a property name or value is invalid. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -103,7 +103,7 @@ export const sceneToolDefinitions = [
   {
     name: 'load_sprite',
     description:
-      'Set the texture on an existing Sprite2D, Sprite3D, or TextureRect node. Use this when the node already exists; for new nodes, pass texture via add_node properties. Saves automatically. texturePath must be a real file under projectPath. Returns a plain-text confirmation message naming the loaded texture. Errors if the node is not one of those three classes, or the texture file does not exist.',
+      'Set the texture on an existing Sprite2D, Sprite3D, or TextureRect node. For new nodes, pass texture via add_node properties instead. Saves automatically. texturePath must be a real file under projectPath. Returns a plain-text confirmation message naming the loaded texture. Errors if the node is not one of those three classes, or the texture file does not exist. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
@@ -126,7 +126,7 @@ export const sceneToolDefinitions = [
   {
     name: 'save_scene',
     description:
-      'Re-pack and save a scene, optionally to a different path (save-as). Most mutations (add_node, set_node_properties, delete_nodes, etc.) auto-save — only use this for save-as via newPath, or to re-canonicalize a hand-edited .tscn. Overwrites silently. Returns a plain-text confirmation naming the save path. Errors if the scene file does not exist.',
+      'Re-pack and save a scene, optionally to a different path (save-as). Most mutations (add_node, set_node_properties, delete_nodes, etc.) auto-save — only use this for save-as via newPath, or to re-canonicalize a hand-edited .tscn. Overwrites silently. Returns a plain-text confirmation naming the save path. Errors if the scene file does not exist. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     annotations: { idempotentHint: true },
     inputSchema: {
       type: 'object',
@@ -145,7 +145,7 @@ export const sceneToolDefinitions = [
   {
     name: 'export_mesh_library',
     description:
-      'Export a scene of MeshInstance3D nodes as a MeshLibrary .res file for use in GridMap. Use this when authoring tile palettes for grid-based 3D levels; ignore for 2D or general scene work. The source scene must contain MeshInstance3D children. Pass meshItemNames to export a subset, or omit to export all. Saves the .res to outputPath, overwriting silently. Returns a plain-text confirmation with the exported item count. Errors if the scene contains no valid meshes.',
+      'Export a scene of MeshInstance3D nodes as a MeshLibrary .res file for use in GridMap. For grid-based 3D tile palettes only, not 2D scenes. Source scene must contain MeshInstance3D children. Pass meshItemNames for a subset, or omit for all. Saves to outputPath, overwriting silently. Returns a plain-text confirmation with the exported item count. Errors if the scene contains no valid meshes. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
@@ -168,7 +168,7 @@ export const sceneToolDefinitions = [
   {
     name: 'batch_scene_operations',
     description:
-      'Use this instead of chaining add_node / load_sprite / save_scene calls when you have multiple mutations on the same or related scenes — runs in one Godot process (~3s startup avoided per call) and shares an in-memory scene cache, saving once at the end. Each item picks its own sub-operation (add_node, load_sprite, set_node_properties, save) and supplies its own params; add_node items accept the same promoted spatial params (position, rotation, scale, visible, modulate) as the standalone tool; set_node_properties items accept the same per-update params (nodePath, property, value) and per-operation scenePath and abortOnError as the standalone tool; abortOnError stops on first failure (default false continues). Returns: results[] in input order, each tagged with operation and scenePath plus success or error.',
+      'Use this instead of chaining add_node / load_sprite / save_scene calls when you have multiple mutations on the same or related scenes — runs in one Godot process (~3s startup avoided per call) and shares an in-memory scene cache, saving once at the end. Each item picks its own sub-operation (add_node, load_sprite, set_node_properties, save) and supplies its own params; add_node items accept the same promoted spatial params (position, rotation, scale, visible, modulate) as the standalone tool; set_node_properties items accept the same per-update params (nodePath, property, value) and per-operation scenePath and abortOnError as the standalone tool; abortOnError stops on first failure (default false continues). Returns: results[] in input order, each tagged with operation and scenePath plus success or error. Errors while a Godot runtime session is active on this project; stop_project (or detach_project) clears it.',
     annotations: { destructiveHint: true },
     inputSchema: {
       type: 'object',
@@ -299,7 +299,7 @@ export async function handleCreateScene(
     'Failed to create scene',
     ['Check if the root node type is valid'],
     undefined,
-    { parseStdoutAsJson: true },
+    { parseStdoutAsJson: true, mutatesSceneFile: true },
   );
 }
 
@@ -380,6 +380,8 @@ export async function handleAddNode(
       'Ensure the parent node path exists',
       'If nodeType is a scene path, verify the file exists and loads (.tscn or .scn)',
     ],
+    undefined,
+    { mutatesSceneFile: true },
   );
 }
 
@@ -424,6 +426,8 @@ export async function handleLoadSprite(
     parsed.value.projectPath,
     'Failed to load sprite',
     ['Check if the node is a Sprite2D, Sprite3D, or TextureRect'],
+    undefined,
+    { mutatesSceneFile: true },
   );
 }
 
@@ -454,6 +458,8 @@ export async function handleSaveScene(
     parsed.value.projectPath,
     'Failed to save scene',
     ['Check if the scene file is valid'],
+    undefined,
+    { mutatesSceneFile: true },
   );
 }
 
@@ -492,6 +498,8 @@ export async function handleExportMeshLibrary(
     parsed.value.projectPath,
     'Failed to export mesh library',
     ['Check if the scene contains valid 3D meshes'],
+    undefined,
+    { mutatesSceneFile: true },
   );
 }
 
@@ -521,6 +529,6 @@ export async function handleBatchSceneOperations(
     'Batch scene operations failed',
     ['Check that all scene paths exist', 'Ensure node types are valid'],
     undefined,
-    { parseStdoutAsJson: true },
+    { parseStdoutAsJson: true, mutatesSceneFile: true },
   );
 }

--- a/src/utils/headless-op.ts
+++ b/src/utils/headless-op.ts
@@ -110,6 +110,15 @@ export async function executeSceneOp(
   exceptionSolutions: string[] = ['Ensure Godot is installed correctly'],
   options: { parseStdoutAsJson?: boolean } = {},
 ): Promise<HandlerResult> {
+  // Live-session guard: a running (spawned or attached) engine process keeps
+  // the project's scenes in memory in the same process's game state, while a
+  // headless mutation writes to the scene files on disk. The two views of the
+  // scene race — the engine's save actions and the headless write land in
+  // either order, and the file contents diverge from whichever view the
+  // engine last applied. Reject up front with the remedy instead of letting
+  // an edit report success and then race the running session.
+  const guard = rejectIfLiveSessionOnProject(runner, projectPath);
+  if (guard) return guard;
   try {
     const { stdout, stderr } = await runner.executeOperation(operation, params, projectPath);
     if (!stdout.trim()) {
@@ -165,4 +174,24 @@ export async function executeSceneOp(
       createErrorResponse(`${failurePrefix}: ${getErrorMessage(error)}`, exceptionSolutions),
     );
   }
+}
+
+function rejectIfLiveSessionOnProject(
+  runner: GodotRunner,
+  projectPath: string,
+): HandlerResult | null {
+  const mode = runner.activeSessionMode;
+  const activeProject = runner.activeProjectPath;
+  if (!mode || !activeProject || !isSameProjectPath(activeProject, projectPath)) return null;
+  return err(
+    createErrorResponse(
+      "A live runtime session is active on this project; scene files and the running process's in-memory scene state race when both change. Stop the session before editing scene files.",
+      ['Call stop_project (or detach_project for attached sessions), then retry the scene edit'],
+    ),
+  );
+}
+
+function isSameProjectPath(a: string, b: string): boolean {
+  const norm = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  return norm(a) === norm(b);
 }

--- a/src/utils/headless-op.ts
+++ b/src/utils/headless-op.ts
@@ -2,7 +2,12 @@ import type { GodotRunner } from './godot-runner.js';
 import type { HandlerResult, OperationParams } from '../mcp.types.js';
 import { createErrorResponse, extractGdError, getErrorMessage } from './error-response.js';
 import { createStructuredResponse } from './structured-response.js';
-import { extractJson, parseScriptDiagnostics, type StderrDiagnostic } from './output-parsing.js';
+import {
+  extractJson,
+  normalizeForCompare,
+  parseScriptDiagnostics,
+  type StderrDiagnostic,
+} from './output-parsing.js';
 import { ok, err } from './result.js';
 
 /**
@@ -108,17 +113,12 @@ export async function executeSceneOp(
   failurePrefix: string,
   emptyStdoutSolutions: string[],
   exceptionSolutions: string[] = ['Ensure Godot is installed correctly'],
-  options: { parseStdoutAsJson?: boolean } = {},
+  options: { parseStdoutAsJson?: boolean; mutatesSceneFile?: boolean } = {},
 ): Promise<HandlerResult> {
-  // Live-session guard: a running (spawned or attached) engine process keeps
-  // the project's scenes in memory in the same process's game state, while a
-  // headless mutation writes to the scene files on disk. The two views of the
-  // scene race — the engine's save actions and the headless write land in
-  // either order, and the file contents diverge from whichever view the
-  // engine last applied. Reject up front with the remedy instead of letting
-  // an edit report success and then race the running session.
-  const guard = rejectIfLiveSessionOnProject(runner, projectPath);
-  if (guard) return guard;
+  if (options.mutatesSceneFile) {
+    const guard = rejectIfLiveSessionOnProject(runner, projectPath);
+    if (guard) return guard;
+  }
   try {
     const { stdout, stderr } = await runner.executeOperation(operation, params, projectPath);
     if (!stdout.trim()) {
@@ -176,22 +176,28 @@ export async function executeSceneOp(
   }
 }
 
+// A running (spawned or attached) engine process can write its own project's
+// scene files at any point during its lifetime -- not just in response to an
+// MCP call. An autoload's _process loop calling ResourceSaver.save is enough;
+// no run_script invocation is required. A headless mutation writes the same
+// files from outside that process. Two writers on one file race regardless of
+// which one triggers the write, so the guard covers the whole session rather
+// than trying to serialize around individual calls.
 function rejectIfLiveSessionOnProject(
   runner: GodotRunner,
   projectPath: string,
 ): HandlerResult | null {
-  const mode = runner.activeSessionMode;
+  if (!runner.hasActiveRuntimeSession()) return null;
   const activeProject = runner.activeProjectPath;
-  if (!mode || !activeProject || !isSameProjectPath(activeProject, projectPath)) return null;
+  const isSameProject =
+    activeProject !== null &&
+    normalizeForCompare(activeProject).toLowerCase() ===
+      normalizeForCompare(projectPath).toLowerCase();
+  if (!isSameProject) return null;
   return err(
     createErrorResponse(
-      "A live runtime session is active on this project; scene files and the running process's in-memory scene state race when both change. Stop the session before editing scene files.",
+      "A Godot runtime session is active on this project. The running process can write this project's scene files at any point while it lives, so a headless edit here would be a second writer racing it. Stop the session before editing scene files.",
       ['Call stop_project (or detach_project for attached sessions), then retry the scene edit'],
     ),
   );
-}
-
-function isSameProjectPath(a: string, b: string): boolean {
-  const norm = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
-  return norm(a) === norm(b);
 }

--- a/tests/helpers/fake-runner.ts
+++ b/tests/helpers/fake-runner.ts
@@ -62,6 +62,11 @@ export function createFakeRunner(options: FakeRunnerOptions = {}): FakeRunner {
 
   const fake = {
     calls,
+    // No live runtime session by default -- tests that need one (e.g. the
+    // executeSceneOp guard tests) set these fields directly on `asRunner`.
+    activeSessionMode: null as 'spawned' | 'attached' | null,
+    activeProjectPath: null as string | null,
+    activeProcess: null as { hasExited: boolean } | null,
     async executeOperation(
       operation: string,
       params: OperationParams,
@@ -77,6 +82,15 @@ export function createFakeRunner(options: FakeRunnerOptions = {}): FakeRunner {
     },
     async getVersion(): Promise<string> {
       return godotVersion;
+    },
+    // Mirrors the real GodotRunner.hasActiveRuntimeSession() predicate so
+    // guard tests exercise the same liveness logic production code does.
+    hasActiveRuntimeSession(): boolean {
+      if (!fake.activeSessionMode || !fake.activeProjectPath) return false;
+      if (fake.activeSessionMode === 'spawned') {
+        return fake.activeProcess !== null && !fake.activeProcess.hasExited;
+      }
+      return true;
     },
   };
 

--- a/tests/unit/godot-runner-extended.test.ts
+++ b/tests/unit/godot-runner-extended.test.ts
@@ -5,7 +5,9 @@ import { join } from 'path';
 import { cleanOutput, normalizeForCompare } from '../../src/utils/output-parsing.js';
 import { parseProjectArgs, parseSceneArgs } from '../../src/utils/arg-parsing.js';
 import { checkDisplayAvailable } from '../../src/utils/path-validation.js';
-import { GodotRunner } from '../../src/utils/godot-runner.js';
+import { GodotRunner, type GodotProcess } from '../../src/utils/godot-runner.js';
+import { createFakeRunner } from '../helpers/fake-runner.js';
+import type { ChildProcess } from 'child_process';
 import { fixtureProjectPath, fixtureScenePath } from '../helpers/fixture-paths.js';
 import { useTmpDirs } from '../helpers/tmp.js';
 import { expectErrorMatching } from '../helpers/assertions.js';
@@ -356,5 +358,127 @@ describe('GodotRunner.attachProject bridge auth token', () => {
     expect(tokenA).not.toBeNull();
     expect(tokenB).not.toBeNull();
     expect(tokenA).not.toBe(tokenB);
+  });
+});
+
+// ─── GodotRunner.hasActiveRuntimeSession ─────────────────────────────────────
+
+const TRACKED_PROJECT = 'D:/projects/demo';
+
+/**
+ * Minimal stand-in for a tracked child process. The predicate reads only
+ * `hasExited`; the rest of GodotProcess is structural padding.
+ */
+function trackedProcess(hasExited: boolean): GodotProcess {
+  return {
+    process: {} as ChildProcess,
+    output: [],
+    errors: [],
+    totalErrorsWritten: 0,
+    exitCode: hasExited ? 0 : null,
+    hasExited,
+    sessionToken: 'test-token',
+  };
+}
+
+describe('GodotRunner.hasActiveRuntimeSession', () => {
+  it('reports no session on a freshly constructed runner', () => {
+    const runner = new GodotRunner({ godotPath: 'godot' });
+
+    expect(runner.hasActiveRuntimeSession()).toBe(false);
+  });
+
+  it('reports a session while a spawned process is still running', () => {
+    const runner = new GodotRunner({ godotPath: 'godot' });
+    runner.activeSessionMode = 'spawned';
+    runner.activeProjectPath = TRACKED_PROJECT;
+    runner.activeProcess = trackedProcess(false);
+
+    expect(runner.hasActiveRuntimeSession()).toBe(true);
+  });
+
+  it('reports no session once the spawned process has exited', () => {
+    // A user closing the game window is the case that has to self-clear:
+    // activeSessionMode and activeProjectPath stay set until stopProject
+    // runs, so anything reading those fields directly would still see a
+    // session here.
+    const runner = new GodotRunner({ godotPath: 'godot' });
+    runner.activeSessionMode = 'spawned';
+    runner.activeProjectPath = TRACKED_PROJECT;
+    runner.activeProcess = trackedProcess(true);
+
+    expect(runner.hasActiveRuntimeSession()).toBe(false);
+  });
+
+  it('reports no session when a spawned launch never produced a process', () => {
+    const runner = new GodotRunner({ godotPath: 'godot' });
+    runner.activeSessionMode = 'spawned';
+    runner.activeProjectPath = TRACKED_PROJECT;
+    runner.activeProcess = null;
+
+    expect(runner.hasActiveRuntimeSession()).toBe(false);
+  });
+
+  it('reports a session in attached mode even with no process tracked', () => {
+    // The server does not own an attached process and never observes its
+    // exit, so attached liveness cannot be falsified from in here.
+    const runner = new GodotRunner({ godotPath: 'godot' });
+    runner.activeSessionMode = 'attached';
+    runner.activeProjectPath = TRACKED_PROJECT;
+    runner.activeProcess = null;
+
+    expect(runner.hasActiveRuntimeSession()).toBe(true);
+  });
+
+  it('reports no session when the project path is unset', () => {
+    const runner = new GodotRunner({ godotPath: 'godot' });
+    runner.activeSessionMode = 'spawned';
+    runner.activeProjectPath = null;
+    runner.activeProcess = trackedProcess(false);
+
+    expect(runner.hasActiveRuntimeSession()).toBe(false);
+  });
+
+  it('reports no session when the session mode is unset', () => {
+    const runner = new GodotRunner({ godotPath: 'godot' });
+    runner.activeSessionMode = null;
+    runner.activeProjectPath = TRACKED_PROJECT;
+    runner.activeProcess = trackedProcess(false);
+
+    expect(runner.hasActiveRuntimeSession()).toBe(false);
+  });
+});
+
+// The guard tests in headless-op.test.ts drive the fake runner, not a real
+// GodotRunner, so the fake carries its own copy of this predicate. If the two
+// ever disagree, those tests go on passing while asserting nothing about
+// production behavior. Pin them together across the whole input space.
+describe('fake runner liveness predicate matches GodotRunner', () => {
+  const CASES: Array<{
+    mode: 'spawned' | 'attached' | null;
+    projectPath: string | null;
+    hasExited: boolean | null;
+  }> = [
+    { mode: null, projectPath: null, hasExited: null },
+    { mode: 'spawned', projectPath: TRACKED_PROJECT, hasExited: false },
+    { mode: 'spawned', projectPath: TRACKED_PROJECT, hasExited: true },
+    { mode: 'spawned', projectPath: TRACKED_PROJECT, hasExited: null },
+    { mode: 'attached', projectPath: TRACKED_PROJECT, hasExited: null },
+    { mode: 'spawned', projectPath: null, hasExited: false },
+    { mode: null, projectPath: TRACKED_PROJECT, hasExited: false },
+  ];
+
+  it.each(CASES)('agrees for mode=$mode path=$projectPath exited=$hasExited', (c) => {
+    const real = new GodotRunner({ godotPath: 'godot' });
+    real.activeSessionMode = c.mode;
+    real.activeProjectPath = c.projectPath;
+    real.activeProcess = c.hasExited === null ? null : trackedProcess(c.hasExited);
+
+    const fake = createFakeRunner().asRunner;
+    fake.activeSessionMode = c.mode;
+    fake.activeProjectPath = c.projectPath;
+    fake.activeProcess = c.hasExited === null ? null : trackedProcess(c.hasExited);
+
+    expect(fake.hasActiveRuntimeSession()).toBe(real.hasActiveRuntimeSession());
   });
 });

--- a/tests/unit/headless-op.test.ts
+++ b/tests/unit/headless-op.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { executeSceneOp } from '../../src/utils/headless-op.js';
 import { createFakeRunner } from '../helpers/fake-runner.js';
+import type { FakeRunner } from '../helpers/fake-runner.js';
 import { hasError, expectErrorMatching, unwrap } from '../helpers/assertions.js';
 import { cleanStdout } from '../../src/utils/output-parsing.js';
 import type { GodotRunner } from '../../src/utils/godot-runner.js';
@@ -18,18 +19,30 @@ const TEST_FAILURE_PREFIX = 'Failed to op';
 const EMPTY_SOLUTIONS = ['empty: a', 'empty: b'];
 const EXCEPTION_SOLUTIONS = ['exc: a', 'exc: b'];
 
-/** Fake runner with live runtime-session state for the guard tests. */
-function runnerWithLiveSession(
-  session: { mode: 'spawned' | 'attached'; projectPath: string } | null,
-): GodotRunner {
+interface LiveSession {
+  mode: 'spawned' | 'attached';
+  projectPath: string;
+  /** Only meaningful for a 'spawned' session. Default: false (process still running). */
+  hasExited?: boolean;
+}
+
+/**
+ * Fake runner with live runtime-session state for the guard tests. Sets the
+ * fields `hasActiveRuntimeSession()` actually reads, so the tests exercise
+ * the real predicate rather than a stand-in.
+ */
+function runnerWithLiveSession(session: LiveSession | null): FakeRunner {
   const fake = createFakeRunner({ stdout: '{"ok":true}' });
   const runner = fake.asRunner as GodotRunner & {
-    activeSessionMode: string | null;
+    activeSessionMode: 'spawned' | 'attached' | null;
     activeProjectPath: string | null;
+    activeProcess: { hasExited: boolean } | null;
   };
   runner.activeSessionMode = session?.mode ?? null;
   runner.activeProjectPath = session?.projectPath ?? null;
-  return fake.asRunner;
+  runner.activeProcess =
+    session?.mode === 'spawned' ? { hasExited: session.hasExited ?? false } : null;
+  return fake;
 }
 
 describe('executeSceneOp', () => {
@@ -122,55 +135,90 @@ describe('executeSceneOp', () => {
 
   describe('live-session scene guard', () => {
     it('errors when mutating a scene while a spawned session is active on the same project', async () => {
-      const runner = runnerWithLiveSession({ mode: 'spawned', projectPath: '/proj' });
+      const fake = runnerWithLiveSession({ mode: 'spawned', projectPath: '/proj' });
       const result = await executeSceneOp(
-        runner,
+        fake.asRunner,
         'add_node',
         { scenePath: 'scenes/main.tscn' },
         '/proj',
         TEST_FAILURE_PREFIX,
         EMPTY_SOLUTIONS,
         EXCEPTION_SOLUTIONS,
+        { mutatesSceneFile: true },
       );
       expectErrorMatching(result, /active.*session|session.*active/i);
-      expect(runner.calls.length).toBe(0); // rejected before spawning headless Godot
+      expect(fake.calls.length).toBe(0); // rejected before spawning headless Godot
     });
 
     it('errors when mutating a scene while an attached session is active on the same project', async () => {
-      const runner = runnerWithLiveSession({ mode: 'attached', projectPath: '/proj' });
+      const fake = runnerWithLiveSession({ mode: 'attached', projectPath: '/proj' });
       const result = await executeSceneOp(
-        runner,
+        fake.asRunner,
         'attach_script',
         { scenePath: 'scenes/main.tscn' },
         '/proj',
         TEST_FAILURE_PREFIX,
         EMPTY_SOLUTIONS,
         EXCEPTION_SOLUTIONS,
+        { mutatesSceneFile: true },
       );
       expectErrorMatching(result, /active.*session|session.*active/i);
-      expect(runner.calls.length).toBe(0);
+      expect(fake.calls.length).toBe(0);
     });
 
     it('allows scene mutations when no runtime session is active', async () => {
-      const runner = runnerWithLiveSession(null);
+      const fake = runnerWithLiveSession(null);
       const result = await executeSceneOp(
-        runner,
+        fake.asRunner,
         'add_node',
         { scenePath: 'scenes/main.tscn' },
         '/proj',
         TEST_FAILURE_PREFIX,
         EMPTY_SOLUTIONS,
         EXCEPTION_SOLUTIONS,
+        { mutatesSceneFile: true },
       );
       expect(hasError(result)).toBe(false);
-      expect((runner as ReturnType<typeof createFakeRunner>).calls.length).toBe(1);
+      expect(fake.calls.length).toBe(1);
     });
 
     it('allows scene mutations when the live session is on a different project', async () => {
-      const runner = runnerWithLiveSession({ mode: 'spawned', projectPath: '/other' });
+      const fake = runnerWithLiveSession({ mode: 'spawned', projectPath: '/other' });
       const result = await executeSceneOp(
-        runner,
+        fake.asRunner,
         'add_node',
+        { scenePath: 'scenes/main.tscn' },
+        '/proj',
+        TEST_FAILURE_PREFIX,
+        EMPTY_SOLUTIONS,
+        EXCEPTION_SOLUTIONS,
+        { mutatesSceneFile: true },
+      );
+      expect(hasError(result)).toBe(false);
+      expect(fake.calls.length).toBe(1);
+    });
+
+    it('points the caller at stop_project as the remedy', async () => {
+      const fake = runnerWithLiveSession({ mode: 'spawned', projectPath: '/proj' });
+      const result = await executeSceneOp(
+        fake.asRunner,
+        'add_node',
+        { scenePath: 'scenes/main.tscn' },
+        '/proj',
+        TEST_FAILURE_PREFIX,
+        EMPTY_SOLUTIONS,
+        EXCEPTION_SOLUTIONS,
+        { mutatesSceneFile: true },
+      );
+      const solutionsText = JSON.stringify(unwrap(result).content);
+      expect(solutionsText).toMatch(/stop_project/i);
+    });
+
+    it('allows a read-only op (no mutatesSceneFile) while a session is live on the same project', async () => {
+      const fake = runnerWithLiveSession({ mode: 'spawned', projectPath: '/proj' });
+      const result = await executeSceneOp(
+        fake.asRunner,
+        'get_scene_tree',
         { scenePath: 'scenes/main.tscn' },
         '/proj',
         TEST_FAILURE_PREFIX,
@@ -178,22 +226,43 @@ describe('executeSceneOp', () => {
         EXCEPTION_SOLUTIONS,
       );
       expect(hasError(result)).toBe(false);
-      expect((runner as ReturnType<typeof createFakeRunner>).calls.length).toBe(1);
+      expect(fake.calls.length).toBe(1);
     });
 
-    it('points the caller at stop_project as the remedy', async () => {
-      const runner = runnerWithLiveSession({ mode: 'spawned', projectPath: '/proj' });
+    it('does not block a mutating op once the spawned process has exited', async () => {
+      const fake = runnerWithLiveSession({
+        mode: 'spawned',
+        projectPath: '/proj',
+        hasExited: true,
+      });
       const result = await executeSceneOp(
-        runner,
+        fake.asRunner,
         'add_node',
         { scenePath: 'scenes/main.tscn' },
         '/proj',
         TEST_FAILURE_PREFIX,
         EMPTY_SOLUTIONS,
         EXCEPTION_SOLUTIONS,
+        { mutatesSceneFile: true },
       );
-      const solutionsText = JSON.stringify(unwrap(result).content);
-      expect(solutionsText).toMatch(/stop_project/i);
+      expect(hasError(result)).toBe(false);
+      expect(fake.calls.length).toBe(1);
+    });
+
+    it('tolerates a trailing slash and a "." segment when comparing project paths', async () => {
+      const fake = runnerWithLiveSession({ mode: 'spawned', projectPath: '/proj/' });
+      const result = await executeSceneOp(
+        fake.asRunner,
+        'add_node',
+        { scenePath: 'scenes/main.tscn' },
+        '/proj/./',
+        TEST_FAILURE_PREFIX,
+        EMPTY_SOLUTIONS,
+        EXCEPTION_SOLUTIONS,
+        { mutatesSceneFile: true },
+      );
+      expectErrorMatching(result, /active.*session|session.*active/i);
+      expect(fake.calls.length).toBe(0);
     });
   });
 });

--- a/tests/unit/headless-op.test.ts
+++ b/tests/unit/headless-op.test.ts
@@ -12,10 +12,25 @@ import { executeSceneOp } from '../../src/utils/headless-op.js';
 import { createFakeRunner } from '../helpers/fake-runner.js';
 import { hasError, expectErrorMatching, unwrap } from '../helpers/assertions.js';
 import { cleanStdout } from '../../src/utils/output-parsing.js';
+import type { GodotRunner } from '../../src/utils/godot-runner.js';
 
 const TEST_FAILURE_PREFIX = 'Failed to op';
 const EMPTY_SOLUTIONS = ['empty: a', 'empty: b'];
 const EXCEPTION_SOLUTIONS = ['exc: a', 'exc: b'];
+
+/** Fake runner with live runtime-session state for the guard tests. */
+function runnerWithLiveSession(
+  session: { mode: 'spawned' | 'attached'; projectPath: string } | null,
+): GodotRunner {
+  const fake = createFakeRunner({ stdout: '{"ok":true}' });
+  const runner = fake.asRunner as GodotRunner & {
+    activeSessionMode: string | null;
+    activeProjectPath: string | null;
+  };
+  runner.activeSessionMode = session?.mode ?? null;
+  runner.activeProjectPath = session?.projectPath ?? null;
+  return fake.asRunner;
+}
 
 describe('executeSceneOp', () => {
   it('returns the runner stdout verbatim when non-empty (no isError)', async () => {
@@ -103,6 +118,83 @@ describe('executeSceneOp', () => {
     const solutionsText = unwrap(result).content[1]?.text ?? '';
     expect(solutionsText).toContain('exc: a');
     expect(solutionsText).not.toContain('empty: a');
+  });
+
+  describe('live-session scene guard', () => {
+    it('errors when mutating a scene while a spawned session is active on the same project', async () => {
+      const runner = runnerWithLiveSession({ mode: 'spawned', projectPath: '/proj' });
+      const result = await executeSceneOp(
+        runner,
+        'add_node',
+        { scenePath: 'scenes/main.tscn' },
+        '/proj',
+        TEST_FAILURE_PREFIX,
+        EMPTY_SOLUTIONS,
+        EXCEPTION_SOLUTIONS,
+      );
+      expectErrorMatching(result, /active.*session|session.*active/i);
+      expect(runner.calls.length).toBe(0); // rejected before spawning headless Godot
+    });
+
+    it('errors when mutating a scene while an attached session is active on the same project', async () => {
+      const runner = runnerWithLiveSession({ mode: 'attached', projectPath: '/proj' });
+      const result = await executeSceneOp(
+        runner,
+        'attach_script',
+        { scenePath: 'scenes/main.tscn' },
+        '/proj',
+        TEST_FAILURE_PREFIX,
+        EMPTY_SOLUTIONS,
+        EXCEPTION_SOLUTIONS,
+      );
+      expectErrorMatching(result, /active.*session|session.*active/i);
+      expect(runner.calls.length).toBe(0);
+    });
+
+    it('allows scene mutations when no runtime session is active', async () => {
+      const runner = runnerWithLiveSession(null);
+      const result = await executeSceneOp(
+        runner,
+        'add_node',
+        { scenePath: 'scenes/main.tscn' },
+        '/proj',
+        TEST_FAILURE_PREFIX,
+        EMPTY_SOLUTIONS,
+        EXCEPTION_SOLUTIONS,
+      );
+      expect(hasError(result)).toBe(false);
+      expect((runner as ReturnType<typeof createFakeRunner>).calls.length).toBe(1);
+    });
+
+    it('allows scene mutations when the live session is on a different project', async () => {
+      const runner = runnerWithLiveSession({ mode: 'spawned', projectPath: '/other' });
+      const result = await executeSceneOp(
+        runner,
+        'add_node',
+        { scenePath: 'scenes/main.tscn' },
+        '/proj',
+        TEST_FAILURE_PREFIX,
+        EMPTY_SOLUTIONS,
+        EXCEPTION_SOLUTIONS,
+      );
+      expect(hasError(result)).toBe(false);
+      expect((runner as ReturnType<typeof createFakeRunner>).calls.length).toBe(1);
+    });
+
+    it('points the caller at stop_project as the remedy', async () => {
+      const runner = runnerWithLiveSession({ mode: 'spawned', projectPath: '/proj' });
+      const result = await executeSceneOp(
+        runner,
+        'add_node',
+        { scenePath: 'scenes/main.tscn' },
+        '/proj',
+        TEST_FAILURE_PREFIX,
+        EMPTY_SOLUTIONS,
+        EXCEPTION_SOLUTIONS,
+      );
+      const solutionsText = JSON.stringify(unwrap(result).content);
+      expect(solutionsText).toMatch(/stop_project/i);
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

A live engine session (`run_project` or `attach_project`) and a headless scene-mutation operation (`add_node`, `set_node_properties`, `attach_script`, ...) hold two views of the same scene: the running process's in-memory state and the `.tscn` on disk. When both change concurrently, the write the caller observes depends on which view lands last — a headless edit can report success and still race the running session's subsequent save, and the tool cannot know which outcome occurred.

Observed from a consumer trace: six `attach_script` / `set_node_properties` calls returned `success: true` while a spawned session cycled on the same project, and the resulting disk state did not reflect the later calls (the file's mtime predated them). Regardless of which side "wins" a given race, the tool reporting success for an edit racing a live process is unsound — the caller has no way to know the edit is effective.

## Fix

Guard `executeSceneOp` — the shared path for all 15 scene/node mutation handlers in `scene-tools.ts` and `node-tools.ts` — to reject the operation up front when a spawned or attached session is active **on the same project** (path-normalized, case-insensitive comparison):

```
A live runtime session is active on this project; scene files and the running
process's in-memory scene state race when both change. Stop the session before
editing scene files.
```

with the remedy named one call away (`stop_project`, or `detach_project` for attached sessions).

Scope boundaries:

- Sessions on a **different** project are unaffected — the guard compares project paths, not mere session presence.
- Read-only scene tools (`get_scene_tree`, `get_node_properties`, `validate`, ...) are unaffected: they do not route through `executeSceneOp`.
- Runtime tools (`run_script`, `simulate_input`, ...) are intentionally not guarded — mutating scene *files* is the hazard; live-state changes through the bridge are the sanctioned way to interact with a running session.

## Tests

Five new cases in `tests/unit/headless-op.test.ts` (written failing-first):

- rejects when a `spawned` session is active on the same project (and asserts the headless Godot process was never spawned — rejection happens before any side effect)
- rejects for `attached` sessions likewise
- allows mutations when no session is active
- allows mutations when the live session is on a different project
- error message names `stop_project` as the remedy

Full suite: 1125 passed, typecheck/lint/prettier clean.
